### PR TITLE
add delete by olid method and .json URL generator

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -76,6 +76,18 @@ class OpenLibrary(object):
         if 'Set-Cookie' not in response.headers:
             raise ValueError("No cookie set")
 
+    def delete(self, olid, comment):
+        """Delete a single Open Library entity by olid (str)
+        CAUTION: This does not make any checks for backreference consistency,
+        Editions could be orphaned, or books left without Authors. Use with care!
+        """
+        data = json.dumps({
+                'type': { 'key': '/type/delete' },
+                '_comment': comment
+               })
+        url = self._generate_url_from_olid(olid)
+        return self.session.put(url, data=data)
+
     @property
     def Work(ol_self):
         """
@@ -592,6 +604,12 @@ class OpenLibrary(object):
         if _olid == u'add':
             raise ValueError('Creation failed, book may already exist!')
         return self.Edition.get(_olid)
+
+    def _generate_url_from_olid(self, olid):
+        """Returns the .json url for an olid (str)"""
+        ol_paths = {'OL..A': 'authors', 'OL..M': 'books', 'OL..W': 'works'}
+        kind = re.sub('\d+', '..', olid)
+        return "%s/%s/%s.json" % (self.base_url, ol_paths[kind], olid)
 
     @staticmethod
     def _extract_olid_from_url(url, url_type):


### PR DESCRIPTION
TODO: maybe add a `delete()` to the `Work`, `Edition`, and `Author` classes?

Current usage:

```
from olclient.openlibrary import OpenLibrary
ol = OpenLibrary()

ol.delete('OL...W', 'Deleting Work')
==> <Response [200]>

ol.delete('OL...A', 'Deleting Author')
==> <Response [200]>
```

I'm using it to delete lists of olids with this code:
```
def delete_list(olid_list, comment):
    for olid in olid_list:
        r = ol.delete(olid, comment)
        print "%s: %s" % (olid, r)
        if r.status_code != 200:
            print "%s response: %s" % (olid, r.content)
```
