### PR TITLE
Mac OS X support for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,19 @@ python:
   - "3.5"
   - "3.6"
 
+matrix:
+  include:
+    - language: generic
+      python: 3.6
+      os: osx
+      before_install:
+        # brew install below does auto-update first which adds ~2 min.
+        # HOMEBREW_AUTO_UPDATE_SECS or HOMEBREW_NO_AUTO_UPDATE might help
+        - brew install python3 yaz
+        - virtualenv ~/env -p python3
+        - source ~/env/bin/activate
+        - pip install pytest
+
 addons:
   apt:
     sources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backoff==1.3.1
 cffi==1.8.2
-cryptography==1.5
+cryptography==1.8
 enum34==1.1.6
 idna==2.1
 ipaddress==1.0.16


### PR DESCRIPTION
This adds support for OS X to the CI build.

It needs a later version (1.8) of the cryptography package that includes binary wheels for this version of OS X to keep from having to build from source (which doesn't work due to misplaced headers), but I didn't see any reason for the hard pin to cryptography 1.5. 

This is another piece for #17 