### PR TITLE
Adding subjects preserves order

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -14,7 +14,7 @@ import requests
 
 from . import common
 from .config import Config
-
+from .utils import merge_unique_lists
 
 logger = logging.getLogger('openlibrary')
 
@@ -153,7 +153,7 @@ class OpenLibrary(object):
                 url = self.OL.base_url + "/works/" + self.olid + ".json"
                 data = self.OL.session.get(url).json()
                 original_subjects = data.get('subjects', [])
-                changed_subjects = self.OL._merge_unique_lists([original_subjects, subjects])
+                changed_subjects = merge_unique_lists([original_subjects, subjects])
                 data['_comment'] = comment or ('adding %s to subjects' % ', '.join(subjects))
                 data['subjects'] = changed_subjects
                 return self.OL.session.put(url, json.dumps(data))
@@ -658,18 +658,6 @@ class OpenLibrary(object):
         except AttributeError:
             return None  # No match
 
-    @staticmethod
-    def _merge_unique_lists(lists, hash_fn=None):
-        """ Combine unique lists into a new unique list. Preserves ordering."""
-        result = []
-        seen = set()
-        for lst in lists:
-            for el in lst:
-                hsh = hash_fn(el) if hash_fn else el
-                if hsh not in seen:
-                    result.append(el)
-                    seen.add(hsh)
-        return result
 
 class Results(object):
 

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -151,13 +151,12 @@ class OpenLibrary(object):
 
             def add_subjects(self, subjects, comment=''):
                 url = self.OL.base_url + "/works/" + self.olid + ".json"
-                r = self.OL.session.get(url)
-                data = r.json()
-                changed_subjects = self.OL._merge_unique_lists([data.get('subjects', []), subjects])
-                if changed_subjects != data.get('subjects', []):
-                    data['_comment'] = comment or ('adding %s to subjects' % ', '.join(subjects))
-                    data['subjects'] = changed_subjects
-                    return self.OL.session.put(url, json.dumps(data))
+                data = self.OL.session.get(url).json()
+                original_subjects = data.get('subjects', [])
+                changed_subjects = self.OL._merge_unique_lists([original_subjects, subjects])
+                data['_comment'] = comment or ('adding %s to subjects' % ', '.join(subjects))
+                data['subjects'] = changed_subjects
+                return self.OL.session.put(url, json.dumps(data))
 
             def rm_subjects(self, subjects, comment=''):
                 url = self.OL.base_url + "/works/" + self.olid + ".json"
@@ -661,9 +660,7 @@ class OpenLibrary(object):
 
     @staticmethod
     def _merge_unique_lists(lists, hash_fn=None):
-        """
-        Combine unique lists into a new unique list. Preserves ordering.
-        """
+        """ Combine unique lists into a new unique list. Preserves ordering."""
         result = []
         seen = set()
         for lst in lists:

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -155,7 +155,7 @@ class OpenLibrary(object):
                 data = r.json()
                 changed_subjects = self.OL._merge_unique_lists([data.get('subjects', []), subjects])
                 if changed_subjects != data.get('subjects', []):
-                    data['_comment'] = comment or ('adding %s to subjects' % subjects)
+                    data['_comment'] = comment or ('adding %s to subjects' % ', '.join(subjects))
                     data['subjects'] = changed_subjects
                     return self.OL.session.put(url, json.dumps(data))
 

--- a/olclient/utils.py
+++ b/olclient/utils.py
@@ -25,7 +25,6 @@ def has_unicode(text):
     """
     return not all(ord(char) < 128 for char in text)
 
-
 def chunks(seq, chunk_size):
     """Returns a generator which yields contiguous chunks of the sequence
     of size (up to) `chunk_size`.
@@ -63,3 +62,15 @@ def parse_datetime(value):
     else:
         tokens = re.split(r'-|T|:|\.| ', value)
         return datetime.datetime(*map(int, tokens))
+
+def merge_unique_lists(lists, hash_fn=None):
+    """ Combine unique lists into a new unique list. Preserves ordering."""
+    result = []
+    seen = set()
+    for lst in lists:
+        for el in lst:
+            hsh = hash_fn(el) if hash_fn else el
+            if hsh not in seen:
+                result.append(el)
+                seen.add(hsh)
+    return result

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -71,6 +71,18 @@ class TestOpenLibrary(unittest.TestCase):
         work = self.ol.Work.get(u'OL12938932W')
         self.assertTrue(work.title.lower() == 'all quiet on the western front',
                         "Failed to retrieve work")
+
+    def test_merge_unique_lists(self):
+        test_data = [
+            {'in': [[1,2], [2,3]], 'expect': [1, 2, 3]},
+            {'in': [[1,2,2,2], [2, 2, 3]], 'expect': [1, 2, 3]},
+            {'in': [[9, 10]], 'expect': [9, 10]},
+            {'in': [[1, 1, 1, 1]], 'expect': [1]},
+            {'in': [], 'expect': []},
+            {'in': [[2], [1]], 'expect': [2, 1]}
+        ]
+        for case in test_data:
+            assert(self.ol._merge_unique_lists(case['in']) == case['expect'])
         
     def test_cli(self):
         expected = json.loads("""{"subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "py/object": "olclient.openlibrary.Edition", "edition_name": "2nd ed.", "title": "Artificial intelligence", "_work": null, "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "authors": [{"py/object": "olclient.openlibrary.Author", "bio": "", "name": "Stuart J. Russell", "links": [], "created": "2008-04-01T03:28:50.625462", "identifiers": {}, "alternate_names": ["Stuart; Norvig, Peter Russell"], "birth_date": "", "olid": null}], "publish_places": ["Upper Saddle River, N.J"], "pages": 1080, "publisher": ["Prentice Hall/Pearson Education"], "pagination": "xxviii, 1080 p. :", "work_olid": "OL2896994W", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": {"type": "/type/text", "value": "Includes bibliographical references (p. 987-1043) and index."}, "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "cover": "", "publish_date": "2003", "olid": "OL3702561M"}""")

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -72,18 +72,6 @@ class TestOpenLibrary(unittest.TestCase):
         self.assertTrue(work.title.lower() == 'all quiet on the western front',
                         "Failed to retrieve work")
 
-    def test_merge_unique_lists(self):
-        test_data = [
-            {'in': [[1,2], [2,3]], 'expect': [1, 2, 3]},
-            {'in': [[1,2,2,2], [2, 2, 3]], 'expect': [1, 2, 3]},
-            {'in': [[9, 10]], 'expect': [9, 10]},
-            {'in': [[1, 1, 1, 1]], 'expect': [1]},
-            {'in': [], 'expect': []},
-            {'in': [[2], [1]], 'expect': [2, 1]}
-        ]
-        for case in test_data:
-            assert(self.ol._merge_unique_lists(case['in']) == case['expect'])
-        
     def test_cli(self):
         expected = json.loads("""{"subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "py/object": "olclient.openlibrary.Edition", "edition_name": "2nd ed.", "title": "Artificial intelligence", "_work": null, "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "authors": [{"py/object": "olclient.openlibrary.Author", "bio": "", "name": "Stuart J. Russell", "links": [], "created": "2008-04-01T03:28:50.625462", "identifiers": {}, "alternate_names": ["Stuart; Norvig, Peter Russell"], "birth_date": "", "olid": null}], "publish_places": ["Upper Saddle River, N.J"], "pages": 1080, "publisher": ["Prentice Hall/Pearson Education"], "pagination": "xxviii, 1080 p. :", "work_olid": "OL2896994W", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": {"type": "/type/text", "value": "Includes bibliographical references (p. 987-1043) and index."}, "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "cover": "", "publish_date": "2003", "olid": "OL3702561M"}""")
         

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+#-*- encoding: utf-8 -*-
+
+"""Test Cases for utilities.""" 
+
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+from olclient.utils import merge_unique_lists
+
+class TestUtils(unittest.TestCase):
+
+    def test_merge_unique_lists(self):
+        test_data = [
+            {'in': [[1,2], [2,3]], 'expect': [1, 2, 3]},
+            {'in': [[1,2,2,2], [2, 2, 3]], 'expect': [1, 2, 3]},
+            {'in': [[9, 10]], 'expect': [9, 10]},
+            {'in': [[1, 1, 1, 1]], 'expect': [1]},
+            {'in': [], 'expect': []},
+            {'in': [[2], [1]], 'expect': [2, 1]}
+        ]
+        for case in test_data:
+            assert(merge_unique_lists(case['in']) == case['expect'])


### PR DESCRIPTION
Also adds the generic method `_merge_unique_lists`  from @cdrini which we have been using to merge works, in preparation for adding merge functionality to the client.