### PR TITLE
Fix 2 issues with editions

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -295,16 +295,17 @@ class OpenLibrary(object):
                     'publisher': data.pop('publishers', u''),
                     'publish_date': data.pop('publish_date', u''),
                     'number_of_pages': data.pop('number_of_pages', u''),
-                    'identifiers': {
-                        'oclc': data.pop('oclc_numbers', []),
-                        'ocaid': data.pop('ocaid', []),
-                        'isbn_10': data.pop('isbn_10', []),
-                        'isbn_13': data.pop('isbn_13', []),
-                        'lccn': data.pop('lccn', [])
-                    },
+                    'identifiers': data.pop('identifiers', {}),
                     'authors': [cls.OL.Author.get(author['key'].split('/')[-1])
                                 for author in data.pop('authors', [])]
                 }
+                book_args['identifiers'].update({
+                    'oclc': data.pop('oclc_numbers', []),
+                    'ocaid': data.pop('ocaid', []),
+                    'isbn_10': data.pop('isbn_10', []),
+                    'isbn_13': data.pop('isbn_13', []),
+                    'lccn': data.pop('lccn', [])
+                })
                 book_args.update(data)
                 return book_args
 

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -290,7 +290,7 @@ class OpenLibrary(object):
             def _ol_edition_json_to_book_args(cls, data):
                 book_args = {
                     'edition_olid': data.pop('key', u'').split('/')[-1],
-                    'work_olid': data.pop('works', [])[0]['key'].split('/')[-1],
+                    'work_olid': ('works' in data or None) and data.pop('works')[0]['key'].split('/')[-1],
                     'title': data.pop('title', u''),
                     'publisher': data.pop('publishers', u''),
                     'publish_date': data.pop('publish_date', u''),

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -81,6 +81,7 @@ class TestOpenLibrary(unittest.TestCase):
         }
         actual = self.ol.Edition._ol_edition_json_to_book_args(edition_data)
         self.assertEquals(actual['identifiers']['isbn_10'], '1234567890')
+        self.assertEquals(actual['identifiers']['goodreads'], '12345')
 
     def test_ol_edition_without_work(self):
         edition_data = {'key': '/books/OL1234M'} # has no 'works' key

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -80,8 +80,8 @@ class TestOpenLibrary(unittest.TestCase):
             'identifiers': {'goodreads': ['12345']}
         }
         actual = self.ol.Edition._ol_edition_json_to_book_args(edition_data)
-        self.assertEquals(actual['identifiers']['isbn_10'], '1234567890')
-        self.assertEquals(actual['identifiers']['goodreads'], '12345')
+        self.assertEquals(actual['identifiers']['isbn_10'], ['1234567890'])
+        self.assertEquals(actual['identifiers']['goodreads'], ['12345'])
 
     def test_ol_edition_without_work(self):
         edition_data = {'key': '/books/OL1234M'} # has no 'works' key

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -71,7 +71,22 @@ class TestOpenLibrary(unittest.TestCase):
         work = self.ol.Work.get(u'OL12938932W')
         self.assertTrue(work.title.lower() == 'all quiet on the western front',
                         "Failed to retrieve work")
-        
+
+    def test_ol_edition_json_to_book_args(self):
+        edition_data = {
+            'key': '/books/OL1234M',
+            'works': [{'key': '/works/OL12W'}],
+            'isbn_10': ['1234567890'],
+            'identifiers': {'goodreads': ['12345']}
+        }
+        actual = self.ol.Edition._ol_edition_json_to_book_args(edition_data)
+        self.assertEquals(actual['identifiers']['isbn_10'], '1234567890')
+
+    def test_ol_edition_without_work(self):
+        edition_data = {'key': '/books/OL1234M'} # has no 'works' key
+        actual = self.ol.Edition._ol_edition_json_to_book_args(edition_data)
+        self.assertIsNone(actual['work_olid'])
+
     def test_cli(self):
         expected = json.loads("""{"subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "py/object": "olclient.openlibrary.Edition", "edition_name": "2nd ed.", "title": "Artificial intelligence", "_work": null, "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "authors": [{"py/object": "olclient.openlibrary.Author", "bio": "", "name": "Stuart J. Russell", "links": [], "created": "2008-04-01T03:28:50.625462", "identifiers": {}, "alternate_names": ["Stuart; Norvig, Peter Russell"], "birth_date": "", "olid": null}], "publish_places": ["Upper Saddle River, N.J"], "pages": 1080, "publisher": ["Prentice Hall/Pearson Education"], "pagination": "xxviii, 1080 p. :", "work_olid": "OL2896994W", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": {"type": "/type/text", "value": "Includes bibliographical references (p. 987-1043) and index."}, "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "cover": "", "publish_date": "2003", "olid": "OL3702561M"}""")
         


### PR DESCRIPTION
* ISBN data was lost if an edition already had `identifiers` (such as goodreads or librarything) populated
* `get`ting an orphaned Edition (one without `works` ) would error with index out of range. Now `work_olid` is set to `None`

There is currently one old test failing, see https://travis-ci.org/hornc/openlibrary-client/jobs/279754532
the expectation data has the old `u'identifiers': {u'goodreads': [u'27543'], u'librarything': [u'43569']}` but does not contain the ISBN anywhere in the data.

After this fix, identifiers are: `u'identifiers': {u'lccn': [u'2003269366'], u'isbn_13': [], u'isbn_10': [u'0137903952'], u'oclc': [], u'ocaid': [], u'librarything': [u'43569'], u'goodreads': [u'27543']}`

The expectation data should be updated.

