### PR TITLE
Improvements to Edition schema

### DIFF
--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -132,8 +132,9 @@
 
     "table_of_contents":   { "type": "array" },
 
-    "description": { "$ref": "#/definitions/text_block" },
-    "notes":       { "$ref": "#/definitions/text_block" },
+    "description":    { "$ref": "#/definitions/text_block" },
+    "first_sentence": { "$ref": "#/definitions/text_block" },
+    "notes":          { "$ref": "#/definitions/text_block" },
 
     "revision":        { "type": "number" },
     "latest_revision": { "type": "number" },

--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -128,7 +128,7 @@
     "series":              { "$ref": "#/definitions/string_array" },
     "source_records":      { "$ref": "#/definitions/string_array" },
     "subjects":            { "$ref": "#/definitions/string_array" },
-    "work_title":          { "$ref": "#/definitions/string_array" },
+    "work_titles":         { "$ref": "#/definitions/string_array" },
 
     "table_of_contents":   { "type": "array" },
 


### PR DESCRIPTION
`work_title` still exists on many OL Edition records, but there are more `work_titles`, and `work_titles` (plural) is consistent with other property names that are lists.

Any record that has a list `work_title` should have it converted to `work_titles`. I don't believe either of these fields are accessible via the UI. There is an `other_titles` property that appears on Librarian mode for editions, `work_titles` seems to be a work level `other_titles`?  Converting all `work_title` to `work_titles` feels like an easy first step before making sense of the multiple titles fields... 