### PR TITLE
Fix author_roles defn. Add links

### DIFF
--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -216,9 +216,19 @@
     },
     "link": {
       "type": "object",
-      "required": [ "url", "title" ],
+      "required": [ "type", "url", "title" ],
       "additionalProperties": false,
       "properties": {
+        "type": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["key"],
+          "properties": {
+            "key": {
+              "enum": ["/type/link"]
+            }
+          }
+        },
         "url":   { "type": "string" },
         "title": { "type": "string" }
       }

--- a/olclient/schemata/work.schema.json
+++ b/olclient/schemata/work.schema.json
@@ -59,10 +59,18 @@
       "required": [ "type", "author" ],
       "properties": {
         "type": {
-          "type": "string",
-          "enum": ["/type/author_role"]
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["key"],
+          "properties": {
+            "key": {
+              "enum": ["/type/author_role"]
+            }
+          }
         },
-        "author": { "$ref": "#/definitions/author" }
+        "author": { "$ref": "#/definitions/author" },
+        "role":   { "type": "string" },
+        "as":     { "type": "string" }
       }
     },
     "author": {

--- a/olclient/schemata/work.schema.json
+++ b/olclient/schemata/work.schema.json
@@ -28,8 +28,15 @@
       "type": "array",
       "items": { "$ref": "#definitions/author_role" }
     },
-
-    "id": { 
+    "covers": {
+      "type": "array",
+      "items": { "type": "number" }
+    },
+    "links": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/link" }
+    },
+    "id": {
       "description": "Unsure what this is for, deprecate?",
       "type": "number"
      },
@@ -95,6 +102,25 @@
           "enum": ["/type/datetime"]
         },
         "value": { "type": "string" }
+      }
+    },
+    "link": {
+      "type": "object",
+      "required": [ "type", "url", "title" ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["key"],
+          "properties": {
+            "key": {
+              "enum": ["/type/link"]
+            }
+          }
+        },
+        "url":   { "type": "string" },
+        "title": { "type": "string" }
       }
     }
   }


### PR DESCRIPTION
Both of these are "Kind: embeddable" from the descriptions at https://openlibrary.org/type/author_role and https://openlibrary.org/type/link  as such they should have `type` set with the format `"type": { "key": "/type/<type>"}`. Updating the json schema for both to reflect this.

Unfortunately in the current work data for author_roles, there is a pretty even mix of `type` styles:
`"authors": [{"type": "/type/author_role"`   => **8,280,196**
vs
`"authors": [{"type": {"key": "/type/author_role"}`  => **7,743,184**

'links` in works are fully consistent, all use the "type: key:" style, I used that as the model for how an OL embeddable type should be.