### PR TITLE
Shared definitions file for schemata, closes #51

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md
 include requirements.txt
 include olclient/schemata/edition.schema.json
 include olclient/schemata/work.schema.json
+include olclient/schemata/shared_definitions.json

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -5,10 +5,10 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import namedtuple
-from pkg_resources import resource_filename
 import json
 import jsonschema
 import logging
+import os
 import re
 
 import backoff
@@ -137,7 +137,7 @@ class OpenLibrary(object):
                    jsonschema.exceptions.ValidationError if the Work is invalid.
 
                 """
-                schemata_path = resource_filename('olclient', 'schemata/')
+                schemata_path = os.path.dirname(os.path.realpath(__file__)) + '/schemata/'
                 with open(schemata_path + 'work.schema.json') as schema_data:
                     schema = json.load(schema_data)
                     resolver = jsonschema.RefResolver('file://' + schemata_path, schema)
@@ -316,7 +316,7 @@ class OpenLibrary(object):
                    jsonschema.exceptions.ValidationError if the Edition is invalid.
 
                 """
-                schemata_path = resource_filename('olclient', 'schemata/')
+                schemata_path = os.path.dirname(os.path.realpath(__file__)) + '/schemata/'
                 with open(schemata_path + 'edition.schema.json') as schema_data:
                     schema = json.load(schema_data)
                     resolver = jsonschema.RefResolver('file://' + schemata_path, schema)

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -5,9 +5,9 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import namedtuple
-from jsonschema import validate
 from pkg_resources import resource_filename
 import json
+import jsonschema
 import logging
 import re
 
@@ -137,10 +137,11 @@ class OpenLibrary(object):
                    jsonschema.exceptions.ValidationError if the Work is invalid.
 
                 """
-                schema_path = resource_filename('olclient', 'schemata/work.schema.json')
-                with open(schema_path) as schema_data:
+                schemata_path = resource_filename('olclient', 'schemata/')
+                with open(schemata_path + 'work.schema.json') as schema_data:
                     schema = json.load(schema_data)
-                    return validate(self.json(), schema)
+                    resolver = jsonschema.RefResolver('file://' + schemata_path, schema)
+                    return jsonschema.Draft4Validator(schema, resolver=resolver).validate(self.json())
 
             @property
             def editions(self):
@@ -315,10 +316,11 @@ class OpenLibrary(object):
                    jsonschema.exceptions.ValidationError if the Edition is invalid.
 
                 """
-                schema_path = resource_filename('olclient', 'schemata/edition.schema.json')
-                with open(schema_path) as schema_data:
+                schemata_path = resource_filename('olclient', 'schemata/')
+                with open(schemata_path + 'edition.schema.json') as schema_data:
                     schema = json.load(schema_data)
-                    return validate(self.json(), schema)
+                    resolver = jsonschema.RefResolver('file://' + schemata_path, schema)
+                    return jsonschema.Draft4Validator(schema, resolver=resolver).validate(self.json())
 
             def add_bookcover(self, url):
                 """Adds a cover image to this edition"""

--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -27,7 +27,7 @@
     },
     "authors": {
       "type": "array",
-      "items": { "$ref": "#definitions/author" }
+      "items": { "$ref": "shared_definitions.json#author" }
     },
     "works": { "$ref": "#/definitions/works" },
     "identifiers": { "$ref": "#/definitions/identifiers" },
@@ -68,7 +68,7 @@
     },
     "links": {
       "type": "array",
-      "items": { "$ref": "#/definitions/link" }
+      "items": { "$ref": "shared_definitions.json#link" }
     },
     "languages": {
       "type": "array",
@@ -118,28 +118,28 @@
         "12 January 2002"
       ]
     },
-    "publish_places":      { "$ref": "#/definitions/string_array" },
-    "publishers":          { "$ref": "#/definitions/string_array" },
-    "contributions":       { "$ref": "#/definitions/string_array" },
-    "dewey_decimal_class": { "$ref": "#/definitions/string_array" },
-    "genres":              { "$ref": "#/definitions/string_array" },
-    "lc_classifications":  { "$ref": "#/definitions/string_array" },
-    "other_titles":        { "$ref": "#/definitions/string_array" },
-    "series":              { "$ref": "#/definitions/string_array" },
-    "source_records":      { "$ref": "#/definitions/string_array" },
-    "subjects":            { "$ref": "#/definitions/string_array" },
-    "work_titles":         { "$ref": "#/definitions/string_array" },
+    "publish_places":      { "$ref": "shared_definitions.json#string_array" },
+    "publishers":          { "$ref": "shared_definitions.json#string_array" },
+    "contributions":       { "$ref": "shared_definitions.json#string_array" },
+    "dewey_decimal_class": { "$ref": "shared_definitions.json#string_array" },
+    "genres":              { "$ref": "shared_definitions.json#string_array" },
+    "lc_classifications":  { "$ref": "shared_definitions.json#string_array" },
+    "other_titles":        { "$ref": "shared_definitions.json#string_array" },
+    "series":              { "$ref": "shared_definitions.json#string_array" },
+    "source_records":      { "$ref": "shared_definitions.json#string_array" },
+    "subjects":            { "$ref": "shared_definitions.json#string_array" },
+    "work_titles":         { "$ref": "shared_definitions.json#string_array" },
 
     "table_of_contents":   { "type": "array" },
 
-    "description":    { "$ref": "#/definitions/text_block" },
-    "first_sentence": { "$ref": "#/definitions/text_block" },
-    "notes":          { "$ref": "#/definitions/text_block" },
+    "description":    { "$ref": "shared_definitions.json#text_block" },
+    "first_sentence": { "$ref": "shared_definitions.json#text_block" },
+    "notes":          { "$ref": "shared_definitions.json#text_block" },
 
     "revision":        { "type": "number" },
     "latest_revision": { "type": "number" },
-    "created":         { "$ref": "#/definitions/internal_datetime" },
-    "last_modified":   { "$ref": "#/definitions/internal_datetime" }
+    "created":         { "$ref": "shared_definitions.json#internal_datetime" },
+    "last_modified":   { "$ref": "shared_definitions.json#internal_datetime" }
   },
 
   "definitions": {
@@ -154,14 +154,6 @@
       "type": "string",
       "pattern": "^([0-9][- ]*){13}$"
     },
-    "author": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [ "key" ],
-      "properties": {
-        "key": { "$ref": "#/definitions/author_key" }
-      }
-    },
     "works": {
       "type": "array",
       "minItems": 1,
@@ -171,37 +163,13 @@
         "additionalProperties": false,
         "required": [ "key" ],
         "properties": {
-          "key": { "$ref": "#/definitions/work_key" }
+          "key": { "$ref": "shared_definitions.json#work_key" }
         }
       }
-    },
-    "author_key": {
-      "type": "string",
-      "pattern": "^/authors/OL[0-9]+A$"
     },
     "edition_key": {
       "type": "string",
       "pattern": "^/books/OL[0-9]+M$"
-    },
-    "work_key": {
-      "type": "string",
-      "pattern": "^/works/OL[0-9]+W$"
-    },
-    "string_array": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "text_block": {
-      "type": "object",
-      "required": [ "type", "value" ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["/type/text"]
-        },
-        "value": { "type": "string" }
-      }
     },
     "language": {
       "type": "object",
@@ -212,37 +180,6 @@
           "type": "string",
           "pattern": "^/languages/[a-z]{3}$"
         }
-      }
-    },
-    "link": {
-      "type": "object",
-      "required": [ "type", "url", "title" ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["key"],
-          "properties": {
-            "key": {
-              "enum": ["/type/link"]
-            }
-          }
-        },
-        "url":   { "type": "string" },
-        "title": { "type": "string" }
-      }
-    },
-    "internal_datetime": {
-      "type": "object",
-      "required": [ "type", "value" ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["/type/datetime"]
-        },
-        "value": { "type": "string" }
       }
     }
   }

--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -27,7 +27,7 @@
     },
     "authors": {
       "type": "array",
-      "items": { "$ref": "shared_definitions.json#author" }
+      "items": { "$ref": "shared_definitions.json#/author" }
     },
     "works": { "$ref": "#/definitions/works" },
     "identifiers": { "$ref": "#/definitions/identifiers" },
@@ -68,7 +68,7 @@
     },
     "links": {
       "type": "array",
-      "items": { "$ref": "shared_definitions.json#link" }
+      "items": { "$ref": "shared_definitions.json#/link" }
     },
     "languages": {
       "type": "array",
@@ -118,28 +118,28 @@
         "12 January 2002"
       ]
     },
-    "publish_places":      { "$ref": "shared_definitions.json#string_array" },
-    "publishers":          { "$ref": "shared_definitions.json#string_array" },
-    "contributions":       { "$ref": "shared_definitions.json#string_array" },
-    "dewey_decimal_class": { "$ref": "shared_definitions.json#string_array" },
-    "genres":              { "$ref": "shared_definitions.json#string_array" },
-    "lc_classifications":  { "$ref": "shared_definitions.json#string_array" },
-    "other_titles":        { "$ref": "shared_definitions.json#string_array" },
-    "series":              { "$ref": "shared_definitions.json#string_array" },
-    "source_records":      { "$ref": "shared_definitions.json#string_array" },
-    "subjects":            { "$ref": "shared_definitions.json#string_array" },
-    "work_titles":         { "$ref": "shared_definitions.json#string_array" },
+    "publish_places":      { "$ref": "shared_definitions.json#/string_array" },
+    "publishers":          { "$ref": "shared_definitions.json#/string_array" },
+    "contributions":       { "$ref": "shared_definitions.json#/string_array" },
+    "dewey_decimal_class": { "$ref": "shared_definitions.json#/string_array" },
+    "genres":              { "$ref": "shared_definitions.json#/string_array" },
+    "lc_classifications":  { "$ref": "shared_definitions.json#/string_array" },
+    "other_titles":        { "$ref": "shared_definitions.json#/string_array" },
+    "series":              { "$ref": "shared_definitions.json#/string_array" },
+    "source_records":      { "$ref": "shared_definitions.json#/string_array" },
+    "subjects":            { "$ref": "shared_definitions.json#/string_array" },
+    "work_titles":         { "$ref": "shared_definitions.json#/string_array" },
 
     "table_of_contents":   { "type": "array" },
 
-    "description":    { "$ref": "shared_definitions.json#text_block" },
-    "first_sentence": { "$ref": "shared_definitions.json#text_block" },
-    "notes":          { "$ref": "shared_definitions.json#text_block" },
+    "description":    { "$ref": "shared_definitions.json#/text_block" },
+    "first_sentence": { "$ref": "shared_definitions.json#/text_block" },
+    "notes":          { "$ref": "shared_definitions.json#/text_block" },
 
     "revision":        { "type": "number" },
     "latest_revision": { "type": "number" },
-    "created":         { "$ref": "shared_definitions.json#internal_datetime" },
-    "last_modified":   { "$ref": "shared_definitions.json#internal_datetime" }
+    "created":         { "$ref": "shared_definitions.json#/internal_datetime" },
+    "last_modified":   { "$ref": "shared_definitions.json#/internal_datetime" }
   },
 
   "definitions": {
@@ -163,7 +163,7 @@
         "additionalProperties": false,
         "required": [ "key" ],
         "properties": {
-          "key": { "$ref": "shared_definitions.json#work_key" }
+          "key": { "$ref": "shared_definitions.json#/work_key" }
         }
       }
     },

--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -12,7 +12,7 @@
   ],
   "additionalProperties": false,
   "properties": {
-    "key": { "$ref": "#/definitions/edition_key" },
+    "key": { "$ref": "shared_definitions.json#/edition_key" },
     "title":    { "type": "string" },
     "subtitle": { "type": "string" },
     "type": {
@@ -166,10 +166,6 @@
           "key": { "$ref": "shared_definitions.json#/work_key" }
         }
       }
-    },
-    "edition_key": {
-      "type": "string",
-      "pattern": "^/books/OL[0-9]+M$"
     },
     "language": {
       "type": "object",

--- a/olclient/schemata/shared_definitions.json
+++ b/olclient/schemata/shared_definitions.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Open Library Shared Schema Definitions",
+
+  "author": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [ "key" ],
+    "properties": {
+      "key": { "$ref": "#author_key" }
+    }
+  },
+  "author_key": {
+    "type": "string",
+    "pattern": "^/authors/OL[0-9]+A$"
+  },
+  "internal_datetime": {
+    "type": "object",
+    "required": [ "type", "value" ],
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": ["/type/datetime"]
+      },
+      "value": { "type": "string" }
+    }
+  },
+  "link": {
+    "type": "object",
+    "required": [ "url", "title" ],
+    "additionalProperties": false,
+    "properties": {
+      "url":   { "type": "string" },
+      "title": { "type": "string" }
+    }
+  },
+  "string_array": {
+    "type": "array",
+    "items": { "type": "string" }
+  },
+  "text_block": {
+    "type": "object",
+    "required": [ "type", "value" ],
+    "additionalProperties": false,
+    "properties": {
+      "type": {
+        "type": "string",
+        "enum": ["/type/text"]
+      },
+      "value": { "type": "string" }
+    }
+  },
+  "work_key": {
+    "type": "string",
+    "pattern": "^/works/OL[0-9]+W$"
+  }
+}

--- a/olclient/schemata/shared_definitions.json
+++ b/olclient/schemata/shared_definitions.json
@@ -14,6 +14,10 @@
     "type": "string",
     "pattern": "^/authors/OL[0-9]+A$"
   },
+  "edition_key": {
+    "type": "string",
+    "pattern": "^/books/OL[0-9]+M$"
+  },
   "internal_datetime": {
     "type": "object",
     "required": [ "type", "value" ],

--- a/olclient/schemata/work.schema.json
+++ b/olclient/schemata/work.schema.json
@@ -45,6 +45,9 @@
 
     "first_publish_date": { "type": "string" },
 
+    "description":    { "$ref": "#/definitions/text_block" },
+    "notes":          { "$ref": "#/definitions/text_block" },
+
     "revision":        { "type": "number" },
     "latest_revision": { "type": "number" },
     "created":         { "$ref": "#/definitions/internal_datetime" },
@@ -91,6 +94,18 @@
     "string_array": {
       "type": "array",
       "items": { "type": "string" }
+    },
+    "text_block": {
+      "type": "object",
+      "required": [ "type", "value" ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["/type/text"]
+        },
+        "value": { "type": "string" }
+      }
     },
     "internal_datetime": {
       "type": "object",

--- a/olclient/schemata/work.schema.json
+++ b/olclient/schemata/work.schema.json
@@ -11,7 +11,7 @@
   ],
   "additionalProperties": true,
   "properties": {
-    "key": { "$ref": "#/definitions/work_key" },
+    "key": { "$ref": "shared_definitions.json#work_key" },
     "title":    { "type": "string" },
     "subtitle": { "type": "string" },
     "type": {
@@ -34,35 +34,26 @@
     },
     "links": {
       "type": "array",
-      "items": { "$ref": "#/definitions/link" }
+      "items": { "$ref": "shared_definitions.json#link" }
     },
     "id": {
       "description": "Unsure what this is for, deprecate?",
       "type": "number"
      },
-    "lc_classifications":  { "$ref": "#/definitions/string_array" },
-    "subjects":            { "$ref": "#/definitions/string_array" },
+    "lc_classifications":  { "$ref": "shared_definitions.json#string_array" },
+    "subjects":            { "$ref": "shared_definitions.json#string_array" },
 
     "first_publish_date": { "type": "string" },
 
-    "description":    { "$ref": "#/definitions/text_block" },
-    "notes":          { "$ref": "#/definitions/text_block" },
+    "description":    { "$ref": "shared_definitions.json#text_block" },
+    "notes":          { "$ref": "shared_definitions.json#text_block" },
 
     "revision":        { "type": "number" },
     "latest_revision": { "type": "number" },
-    "created":         { "$ref": "#/definitions/internal_datetime" },
-    "last_modified":   { "$ref": "#/definitions/internal_datetime" }
+    "created":         { "$ref": "shared_definitions.json#internal_datetime" },
+    "last_modified":   { "$ref": "shared_definitions.json#internal_datetime" }
   },
   "definitions": {
-
-    "author_key": {
-      "type": "string",
-      "pattern": "^/authors/OL[0-9]+A$"
-    },
-    "work_key": {
-      "type": "string",
-      "pattern": "^/works/OL[0-9]+W$"
-    },
     "author_role": {
       "type": "object",
       "additionalProperties": false,
@@ -78,64 +69,9 @@
             }
           }
         },
-        "author": { "$ref": "#/definitions/author" },
+        "author": { "$ref": "shared_definitions.json#author" },
         "role":   { "type": "string" },
         "as":     { "type": "string" }
-      }
-    },
-    "author": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [ "key" ],
-      "properties": {
-        "key": { "$ref": "#/definitions/author_key" }
-      }
-    },
-    "string_array": {
-      "type": "array",
-      "items": { "type": "string" }
-    },
-    "text_block": {
-      "type": "object",
-      "required": [ "type", "value" ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["/type/text"]
-        },
-        "value": { "type": "string" }
-      }
-    },
-    "internal_datetime": {
-      "type": "object",
-      "required": [ "type", "value" ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["/type/datetime"]
-        },
-        "value": { "type": "string" }
-      }
-    },
-    "link": {
-      "type": "object",
-      "required": [ "type", "url", "title" ],
-      "additionalProperties": false,
-      "properties": {
-        "type": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["key"],
-          "properties": {
-            "key": {
-              "enum": ["/type/link"]
-            }
-          }
-        },
-        "url":   { "type": "string" },
-        "title": { "type": "string" }
       }
     }
   }

--- a/olclient/schemata/work.schema.json
+++ b/olclient/schemata/work.schema.json
@@ -11,7 +11,7 @@
   ],
   "additionalProperties": true,
   "properties": {
-    "key": { "$ref": "shared_definitions.json#work_key" },
+    "key": { "$ref": "shared_definitions.json#/work_key" },
     "title":    { "type": "string" },
     "subtitle": { "type": "string" },
     "type": {
@@ -34,24 +34,24 @@
     },
     "links": {
       "type": "array",
-      "items": { "$ref": "shared_definitions.json#link" }
+      "items": { "$ref": "shared_definitions.json#/link" }
     },
     "id": {
       "description": "Unsure what this is for, deprecate?",
       "type": "number"
      },
-    "lc_classifications":  { "$ref": "shared_definitions.json#string_array" },
-    "subjects":            { "$ref": "shared_definitions.json#string_array" },
+    "lc_classifications":  { "$ref": "shared_definitions.json#/string_array" },
+    "subjects":            { "$ref": "shared_definitions.json#/string_array" },
 
     "first_publish_date": { "type": "string" },
 
-    "description":    { "$ref": "shared_definitions.json#text_block" },
-    "notes":          { "$ref": "shared_definitions.json#text_block" },
+    "description":    { "$ref": "shared_definitions.json#/text_block" },
+    "notes":          { "$ref": "shared_definitions.json#/text_block" },
 
     "revision":        { "type": "number" },
     "latest_revision": { "type": "number" },
-    "created":         { "$ref": "shared_definitions.json#internal_datetime" },
-    "last_modified":   { "$ref": "shared_definitions.json#internal_datetime" }
+    "created":         { "$ref": "shared_definitions.json#/internal_datetime" },
+    "last_modified":   { "$ref": "shared_definitions.json#/internal_datetime" }
   },
   "definitions": {
     "author_role": {
@@ -69,7 +69,7 @@
             }
           }
         },
-        "author": { "$ref": "shared_definitions.json#author" },
+        "author": { "$ref": "shared_definitions.json#/author" },
         "role":   { "type": "string" },
         "as":     { "type": "string" }
       }

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -119,6 +119,19 @@ class TestOpenLibrary(unittest.TestCase):
         self.assertEqual(work_json['key'], "/works/OL12938932W")
         self.assertEqual(work_json['authors'][0]['author']['key'], "/authors/OL5864762A")
 
+    def test_work_validation(self):
+        # TODO: why does work key have to be specified twice when creating a work?
+        work = self.ol.Work('OL123W',
+                            key='/works/OL123W',
+                            title='Test Title',
+                            type={'key': '/type/work'},
+                            revision=1,
+                            last_modified={
+                              'type': '/type/datetime',
+                              'value': '2016-10-12T00:48:04.453554'
+                            })
+        self.assertIsNone(work.validate())
+
     def test_edition_json(self):
         author = self.ol.Author('OL123A', 'Test Author')
         edition = self.ol.Edition(edition_olid='OL123M',


### PR DESCRIPTION
@cdrini good suggestion, and I was able to do the sharing it with relative paths!

I'm not sure whether the structure and naming of `shared_definitions.json` is good enough.. it's just a very simple json file containing the definitions at the top level with a `"$schema": "http://json-schema.org/draft-04/schema#"` (which seems to validate).  Second opinions very much welcome :)

My justification for the current naming and structure is to reduce the length of the `$ref`s , so no `shared_definitions.schema.json` and no `#definitions/<definition>`