### PR TITLE
Add Redirect+Delete classes. Work.add_author(). Exception handling, and handle /type/text

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -648,6 +648,13 @@ class OpenLibrary(object):
                 }
                 return data
 
+            def save(self, comment='delete'):
+                """Saves the Delete back to Open Library using the JSON API."""
+                body = self.json()
+                body['_comment'] = comment
+                url = self.OL._generate_url_from_olid(self.olid)
+                return self.OL.session.put(url, json.dumps(body))
+
         return Delete
 
     @property
@@ -686,11 +693,11 @@ class OpenLibrary(object):
                 }
                 return data
 
-            def save(self, comment):
-                """Saves the redirect back to Open Library using the JSON API."""
+            def save(self, comment='redirect'):
+                """Saves the Redirect back to Open Library using the JSON API."""
                 body = self.json()
                 body['_comment'] = comment
-                url = self.OL.base_url + '/works/%s.json' % self.olid
+                url = self.OL._generate_url_from_olid(self.olid)
                 return self.OL.session.put(url, json.dumps(body))
 
         return Redirect

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -439,8 +439,7 @@ class OpenLibrary(object):
                     edition = cls(**cls._ol_edition_json_to_book_args(data))
                     return edition
                 except:
-                    # XXX Better error handling required
-                    return None
+                    raise Exception("Unable to get Edition with olid: %s" % olid)
 
             @classmethod
             def get_olid_by_ocaid(cls, ocaid):

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -436,10 +436,11 @@ class OpenLibrary(object):
 
                 try:
                     data = response.json()
+                    data['title'] = data.get('title', None)
                     edition = cls(**cls._ol_edition_json_to_book_args(data))
                     return edition
-                except:
-                    raise Exception("Unable to get Edition with olid: %s" % olid)
+                except Exception as e:
+                    raise Exception("Unable to get Edition with olid: %s\nDetails: %s" % (olid, e))
 
             @classmethod
             def get_olid_by_ocaid(cls, ocaid):

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -185,6 +185,12 @@ class OpenLibrary(object):
                 work.add_bookcover(book.cover)
                 return ed
 
+            def add_author(self, author):
+                author_role = {u'type': {u'key': u'/type/author_role'}}
+                author_role[u'author'] = {u'key': u'/authors/' + author.olid}
+                self.authors.append(author_role)
+                return author_role
+
             def add_bookcover(self, url):
                 _url = '%s/works/%s/-/add-cover' % (self.OL.base_url, self.olid)
                 r = self.OL.session.post(_url, files={

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -177,6 +177,17 @@ class TestOpenLibrary(unittest.TestCase):
         self.assertIn('ns=42', called_with_headers['Opt'])
         self.assertEqual('test comment', called_with_headers['42-comment'])
 
+    def test_delete(self):
+        delete = self.ol.Delete('OL1W')
+        self.assertEqual(delete.olid, 'OL1W')
+        self.assertEqual('/type/delete', delete.json()['type']['key'])
+        self.assertEqual('/works/OL1W', delete.json()['key'])
+
+    def test_redirect(self):
+        redirect = self.ol.Redirect(f='OL1W', t='OL2W')
+        self.assertEqual('/type/redirect', redirect.json()['type']['key'])
+        self.assertIn('location', redirect.json())
+
 class TestAuthors(unittest.TestCase):
 
     @patch('olclient.openlibrary.OpenLibrary.login')

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -210,7 +210,7 @@ class TestFullEditionGet(unittest.TestCase):
     target_olid = u'OL3702561M'
     raw_edition = json.loads("""{"number_of_pages": 1080, "subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "edition_name": "2nd ed.", "title": "Artificial intelligence", "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "publishers": ["Prentice Hall/Pearson Education"], "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "key": "/books/OL3702561M", "authors": [{"key": "/authors/OL440500A"}], "publish_places": ["Upper Saddle River, N.J"], "pagination": "xxviii, 1080 p. :", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": {"type": "/type/text", "value": "Includes bibliographical references (p. 987-1043) and index."}, "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "lccn": ["2003269366"], "isbn_10": ["0137903952"], "publish_date": "2003", "works": [{"key": "/works/OL2896994W"}]}""")
     raw_author = json.loads("""{"name": "Stuart J. Russell", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "key": "/authors/OL440500A"}""")
-    expected = json.loads("""{"subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "py/object": "olclient.openlibrary.Edition", "edition_name": "2nd ed.", "title": "Artificial intelligence", "_work": null, "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "authors": [{"py/object": "olclient.openlibrary.Author", "bio": null, "name": "Stuart J. Russell", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "identifiers": {}, "olid": "OL440500A"}], "publish_places": ["Upper Saddle River, N.J"], "pages": 1080, "publisher": null, "publishers": ["Prentice Hall/Pearson Education"], "pagination": "xxviii, 1080 p. :", "work_olid": "OL2896994W", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": {"type": "/type/text", "value": "Includes bibliographical references (p. 987-1043) and index."}, "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "lccn": ["2003269366"], "isbn_10": ["0137903952"], "cover": null, "publish_date": "2003", "olid": "OL3702561M"}""")
+    expected = json.loads("""{"subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "py/object": "olclient.openlibrary.Edition", "edition_name": "2nd ed.", "title": "Artificial intelligence", "_work": null, "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "description": null, "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "authors": [{"py/object": "olclient.openlibrary.Author", "bio": null, "name": "Stuart J. Russell", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "identifiers": {}, "olid": "OL440500A"}], "publish_places": ["Upper Saddle River, N.J"], "pages": 1080, "publisher": null, "publishers": ["Prentice Hall/Pearson Education"], "pagination": "xxviii, 1080 p. :", "work_olid": "OL2896994W", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": {"type": "/type/text", "value": "Includes bibliographical references (p. 987-1043) and index."}, "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "lccn": ["2003269366"], "isbn_10": ["0137903952"], "cover": null, "publish_date": "2003", "olid": "OL3702561M"}""")
         
     @patch('olclient.openlibrary.OpenLibrary.login')
     def setUp(self, mock_login):
@@ -245,3 +245,20 @@ class TestFullEditionGet(unittest.TestCase):
         ])
         self.assertEquals(actual, self.expected,
                         "Data didn't match for olid lookup: %s\n\nversus:\n\n %s" % (actual, self.expected))
+
+class TestTextType(unittest.TestCase):
+
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def setUp(self, mock_login):
+        self.ol = OpenLibrary()
+
+    def test_edition_text(self):
+
+        edition = self.ol.Edition(edition_olid='OL123M',
+                                  work_olid='OL123W',
+                                  title='Test Title',
+                                  description='A Text Description',
+                                  notes='A Text Note'
+                                  )
+        self.assertIn('type', edition.json()['description'])
+        self.assertEquals(edition.json()['description']['value'], "A Text Description")

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -3,6 +3,7 @@
 """Test cases for the OpenLibrary module"""
 
 from __future__ import absolute_import, division, print_function
+from six import string_types
 
 import json
 import jsonpickle
@@ -289,7 +290,7 @@ class TestTextType(unittest.TestCase):
     def test_edition_text_type(self):
         edition = create_edition(self.ol, **self.texts)
         self.assertIsNone(edition.validate())
-        self.assertIsInstance(edition.description, basestring)
+        self.assertIsInstance(edition.description, string_types)
         self.assertIn('type', edition.json()['description'])
         self.assertEquals(edition.json()['description']['value'], "A Text Description")
 
@@ -302,5 +303,6 @@ class TestTextType(unittest.TestCase):
     def test_work_text_type(self):
         work = create_work(self.ol, **self.texts)
         self.assertIsNone(work.validate())
+        self.assertIsInstance(work.description, string_types)
         self.assertIn('type', work.json()['description'])
         self.assertEquals(work.json()['description']['value'], "A Text Description")

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -18,6 +18,30 @@ from olclient.config import Config
 from olclient.common import Author, Book
 from olclient.openlibrary import OpenLibrary
 
+def create_edition(ol, **kwargs):
+    """Creates a basic test Edition."""
+    defaults = {'edition_olid': 'OL123M',
+                'work_olid': 'OL123W',
+                'title': 'Test Title',
+                'revision': 1,
+                'last_modified': {
+                     'type': '/type/datetime',
+                     'value': '2016-10-12T00:48:04.453554'
+                }}
+    defaults.update(kwargs)
+    return ol.Edition(**defaults)
+
+def create_work(ol, **kwargs):
+    """Creates a basic test Work."""
+    defaults = {'olid': 'OL123W',
+                'title':'Test Title',
+                'revision': 1,
+                'last_modified': {
+                    'type': '/type/datetime',
+                    'value': '2016-10-12T00:48:04.453554'
+                }}
+    defaults.update(kwargs)
+    return ol.Work(**defaults)
 
 class TestOpenLibrary(unittest.TestCase):
 
@@ -210,7 +234,7 @@ class TestFullEditionGet(unittest.TestCase):
     target_olid = u'OL3702561M'
     raw_edition = json.loads("""{"number_of_pages": 1080, "subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "edition_name": "2nd ed.", "title": "Artificial intelligence", "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "publishers": ["Prentice Hall/Pearson Education"], "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "key": "/books/OL3702561M", "authors": [{"key": "/authors/OL440500A"}], "publish_places": ["Upper Saddle River, N.J"], "pagination": "xxviii, 1080 p. :", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": {"type": "/type/text", "value": "Includes bibliographical references (p. 987-1043) and index."}, "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "lccn": ["2003269366"], "isbn_10": ["0137903952"], "publish_date": "2003", "works": [{"key": "/works/OL2896994W"}]}""")
     raw_author = json.loads("""{"name": "Stuart J. Russell", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "key": "/authors/OL440500A"}""")
-    expected = json.loads("""{"subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "py/object": "olclient.openlibrary.Edition", "edition_name": "2nd ed.", "title": "Artificial intelligence", "_work": null, "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "description": null, "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "authors": [{"py/object": "olclient.openlibrary.Author", "bio": null, "name": "Stuart J. Russell", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "identifiers": {}, "olid": "OL440500A"}], "publish_places": ["Upper Saddle River, N.J"], "pages": 1080, "publisher": null, "publishers": ["Prentice Hall/Pearson Education"], "pagination": "xxviii, 1080 p. :", "work_olid": "OL2896994W", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": {"type": "/type/text", "value": "Includes bibliographical references (p. 987-1043) and index."}, "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "lccn": ["2003269366"], "isbn_10": ["0137903952"], "cover": null, "publish_date": "2003", "olid": "OL3702561M"}""")
+    expected = json.loads("""{"subtitle": "a modern approach", "series": ["Prentice Hall series in artificial intelligence"], "covers": [92018], "lc_classifications": ["Q335 .R86 2003"], "latest_revision": 6, "contributions": ["Norvig, Peter."], "py/object": "olclient.openlibrary.Edition", "edition_name": "2nd ed.", "title": "Artificial intelligence", "_work": null, "languages": [{"key": "/languages/eng"}], "subjects": ["Artificial intelligence."], "publish_country": "nju", "by_statement": "Stuart J. Russell and Peter Norvig ; contributing writers, John F. Canny ... [et al.].", "type": {"key": "/type/edition"}, "revision": 6, "description": null, "last_modified": {"type": "/type/datetime", "value": "2010-08-03T18:56:51.333942"}, "authors": [{"py/object": "olclient.openlibrary.Author", "bio": null, "name": "Stuart J. Russell", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "identifiers": {}, "olid": "OL440500A"}], "publish_places": ["Upper Saddle River, N.J"], "pages": 1080, "publisher": null, "publishers": ["Prentice Hall/Pearson Education"], "pagination": "xxviii, 1080 p. :", "work_olid": "OL2896994W", "created": {"type": "/type/datetime", "value": "2008-04-01T03:28:50.625462"}, "dewey_decimal_class": ["006.3"], "notes": "Includes bibliographical references (p. 987-1043) and index.", "identifiers": {"librarything": ["43569"], "goodreads": ["27543"]}, "lccn": ["2003269366"], "isbn_10": ["0137903952"], "cover": null, "publish_date": "2003", "olid": "OL3702561M"}""")
         
     @patch('olclient.openlibrary.OpenLibrary.login')
     def setUp(self, mock_login):
@@ -251,14 +275,32 @@ class TestTextType(unittest.TestCase):
     @patch('olclient.openlibrary.OpenLibrary.login')
     def setUp(self, mock_login):
         self.ol = OpenLibrary()
+        self.strings = {u'description':  u'A String Description',
+                        u'notes': u'A String Note'}
+        self.texts   = {u'description': {u'type': u'/type/text', u'value': u'A Text Description'},
+                        u'notes': {u'type': u'/type/text', u'value': u'A Text Note'}}
 
-    def test_edition_text(self):
+    def test_edition_text_type_from_string(self):
+        edition = create_edition(self.ol, **self.strings)
+        self.assertIsNone(edition.validate())
+        self.assertIn('type', edition.json()['description'])
+        self.assertEquals(edition.json()['description']['value'], "A String Description")
 
-        edition = self.ol.Edition(edition_olid='OL123M',
-                                  work_olid='OL123W',
-                                  title='Test Title',
-                                  description='A Text Description',
-                                  notes='A Text Note'
-                                  )
+    def test_edition_text_type(self):
+        edition = create_edition(self.ol, **self.texts)
+        self.assertIsNone(edition.validate())
+        self.assertIsInstance(edition.description, basestring)
         self.assertIn('type', edition.json()['description'])
         self.assertEquals(edition.json()['description']['value'], "A Text Description")
+
+    def test_work_text_type_from_string(self):
+        work = create_work(self.ol, **self.strings)
+        self.assertIsNone(work.validate())
+        self.assertIn('type', work.json()['description'])
+        self.assertEquals(work.json()['description']['value'], "A String Description")
+
+    def test_work_text_type(self):
+        work = create_work(self.ol, **self.texts)
+        self.assertIsNone(work.validate())
+        self.assertIn('type', work.json()['description'])
+        self.assertEquals(work.json()['description']['value'], "A Text Description")


### PR DESCRIPTION
There are a few things in this PR, the last features I needed to get the client reliable and usable for some real data fixing.


1. Adding Redirect and Delete classes so olids can be converted and saved back as `/type/delete` or `/type/redirect` (essential for merging!)

2. Created `Work.add_author()` to conveniently associate authors with works in the correct format.
  **TODO:** 
     * method to remove authors
     * ability to set optional `role` and `as` properties that are present in the schema

3. Better exception handling
  **TODO** 
     * add some tests
     * review all OL classes to ensure they have the same exception handling, refactor common code

4. handle `/type/text` properties consistently on save.
   **TODO**
      * Investigate root cause for why OL / Infogami saves `/type/text` inconsistently 
      * refactor and ensure constructor vs. load from JSON loading of `str`/`/type/text` formats is sensible 