### PR TITLE
Fixes #82: Update setup.cfg in order to exclude dirs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[tool:pytest]
+norecursedirs=lib*


### PR DESCRIPTION
Edit setup.cfg in order to exclude virtualenv directories when running test.py