### PR TITLE
fix ci by rm incomplete mac os checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,6 @@ python:
   - "3.5"
   - "3.6"
 
-matrix:
-  include:
-    - language: generic
-      python: 3.6
-      os: osx
-      before_install:
-        - brew update; brew install python3 yaz
-        - virtualenv ~/env -p python3
-        - source ~/env/bin/activate
-        - pip install pytest
-
 addons:
   apt:
     sources:


### PR DESCRIPTION
This PR closes #93

## Description:
mac osx has been failing due to incomplete travis CI instructions. Dropping support until fixed. 