### PR TITLE
DOCUMENTATION: Include the need for python-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,21 @@ $ sudo apt install yaz
 
 For Fedora/RHEL, use the following command to install `yaz`
 ```
-sudo dnf install yaz
+$ sudo dnf install yaz
 ```
+
+If you haven't got python dev tools yet, you need those too.
+
+```
+$ sudo apt install python-dev   # for python 2
+$ sudo apt install python3-dev  # for python 3
+```
+
+```
+sudo dnf install python2-devel  # for python2.x installs
+sudo dnf install python3-devel  # for python3.x installs
+```
+
 
 To install the openlibrary-client package:
 ```


### PR DESCRIPTION
This PR does not close an existing issue

## Description
To install, we also need python-dev or python3-dev
Also making formatting of docs slightly more consistent