### PR TITLE
Validate identifiers when creating Entities

### DIFF
--- a/olclient/common.py
+++ b/olclient/common.py
@@ -8,10 +8,22 @@ from __future__ import absolute_import, division, print_function
 
 from .utils import rm_punctuation
 
+VALID_IDENTIFIERS = ('olid', 'oclc', 'isbn_10', 'isbn_13')
+
 
 class Entity(object):
     def __init__(self, identifiers):
+        if identifiers is not None:
+            self._validate_identifiers(identifiers)
         self.identifiers = identifiers or {}
+
+    @staticmethod
+    def _validate_identifiers(identifiers):
+        for id_type, values in identifiers.items():
+            if id_type not in VALID_IDENTIFIERS:
+                raise AttributeError("ID type '{}' is not one of {}".format(id_type, VALID_IDENTIFIERS))
+            if type(values) not in (list, tuple):
+                raise TypeError("Identifier values must be lists")
 
     def add_id(self, id_type, identifier):
         """Adds an identifier to this book

--- a/olclient/common.py
+++ b/olclient/common.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 
 from .utils import rm_punctuation
 
-VALID_IDENTIFIERS = ('olid', 'oclc', 'isbn_10', 'isbn_13')
+VALID_IDENTIFIERS = ('olid', 'oclc', 'isbn_10', 'isbn_13', 'lccn')
 
 
 class Entity(object):


### PR DESCRIPTION
This PR closes #98 

## Description:
It's easy to accidentally misformat entity identifier dicts. This PR adds some basic validation to make it a bit harder.

## Usage examples:
```bash
adamreis@Adams-MacBook-Pro ~/G/d/openlibrary-client>
python3 -m olclient.cli --create "{\"title\":\"All We Ever Wanted: A Novel\", \"author\": \"Emily Giffin\", \"identifiers\":{\"isbn_10\": \"0399178929\"}}"

Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/cli.py", line 116, in <module>
    main()
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/cli.py", line 108, in main
    book = common.Book(title, authors=[author], **data)
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/common.py", line 98, in __init__
    super(Book, self).__init__(identifiers=identifiers)
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/common.py", line 17, in __init__
    self._validate_identifiers(identifiers)
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/common.py", line 27, in _validate_identifiers
    raise TypeError("Identifier values must be lists")
TypeError: Identifier values must be lists
```
```bash
adamreis@Adams-MacBook-Pro ~/G/d/openlibrary-client>
python3 -m olclient.cli --create "{\"title\":\"All We Ever Wanted: A Novel\", \"author\": \"Emily Giffin\", \"identifiers\":{\"isbn_100\": \"0399178929\"}}"

Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.6.5/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/cli.py", line 116, in <module>
    main()
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/cli.py", line 108, in main
    book = common.Book(title, authors=[author], **data)
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/common.py", line 98, in __init__
    super(Book, self).__init__(identifiers=identifiers)
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/common.py", line 17, in __init__
    self._validate_identifiers(identifiers)
  File "/Users/adamreis/Google-Drive/dev/openlibrary-client/olclient/common.py", line 24, in _validate_identifiers
    raise AttributeError("ID type {} is not one of {}".format(id_type, VALID_IDENTIFIERS))
AttributeError: ID type isbn_100 is not one of ('olid', 'oclc', 'isbn_10', 'isbn_13')
```
```bash
adamreis@Adams-MacBook-Pro ~/G/d/openlibrary-client>
python3 -m olclient.cli --create "{\"title\":\"All We Ever Wanted: A Novel\", \"author\": \"Emily Giffin\", \"identifiers\":{\"isbn_10\": [\"0399178929\"]}}"
adamreis@Adams-MacBook-Pro ~/G/d/openlibrary-client>
```