### PR TITLE
fixes #60 and related by raising HTTPErrors

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -50,6 +50,7 @@ class OpenLibrary(object):
     BACKOFF_KWARGS = {
         'wait_gen': backoff.expo,
         'exception': requests.exceptions.RequestException,
+        'giveup': lambda e: hasattr(e.response, 'status_code') and 400 <= e.response.status_code < 500,
         'max_tries': 5
     }
 

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -519,25 +519,15 @@ class OpenLibrary(object):
                     or
                     >>> ol.Edition.get(ocaid=u'XXX')
                 """
-                if not olid:
-                    if any([isbn, oclc, lccn, ocaid]):
-                        if isbn:
-                            _id, value = ('isbn', isbn)
-                            olid = cls.get_olid_by_isbn(isbn)
-                        elif oclc:
-                            _id, value = ('oclc', oclc)
-                            olid = cls.get_olid_by_oclc(oclc)
-                        elif ocaid:
-                            _id, value = ('ocaid', ocaid)
-                            olid = cls.get_olid_by_ocaid(ocaid)
-                        else:
-                            _id, value = ('lccn', lccn)
-                            olid = cls.get_olid_by_lccn(lccn)
-                    else:
-                        raise ValueError("Must supply valid olid, isbn, oclc, ocaid, or lccn")
-
-                if olid is None:
-                    raise Exception("No olid found for %s = %s" % (_id, value))
+                if not any([olid, isbn, oclc, lccn, ocaid]):
+                    raise ValueError("Must supply valid olid, isbn, oclc, ocaid, or lccn")
+                elif not olid:
+                    bibkeys = {'ISBN': isbn, 'OCLC': oclc, 'OCAID': ocaid, 'LCCN': lccn}
+                    bibkey, value = [(k, v) for k,v in bibkeys.items() if v][0]
+                    olid = cls.get_olid(bibkey, value)
+                    if not olid:
+                        # No edition found by bibkey
+                        return
 
                 path = '/books/%s.json' % olid
                 response = cls.OL._get_ol_response(path)

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -275,10 +275,11 @@ class OpenLibrary(object):
                 Usage:
                     >>> from olclient.openlibrary import OpenLibrary
                     >>> ol = OpenLibrary()
-                    >>> ol.Work.get('OL26278461M')
+                    >>> ol.Work.get('OL26278461W')
                 """
                 url = '%s/works/%s.json' % (cls.OL.base_url, olid)
                 r = cls.OL.session.get(url)
+                r.raise_for_status()
                 return cls(olid, **r.json())
 
             @classmethod
@@ -533,7 +534,7 @@ class OpenLibrary(object):
                     return cls.OL.session.get(url)
 
                 response = _get_book_by_olid(url)
-
+                response.raise_for_status()
                 try:
                     data = response.json()
                     data['title'] = data.get('title', None)
@@ -603,7 +604,7 @@ class OpenLibrary(object):
 
                 # Let the exception be handled up the stack
                 response = _get_olid(url)
-
+                response.raise_for_status()
                 try:
                     results = response.json()
                 except ValueError as e:
@@ -673,7 +674,7 @@ class OpenLibrary(object):
                 """
                 url = cls.OL.base_url + '/authors/%s.json' % olid
                 r = cls.OL.session.get(url)
-
+                r.raise_for_status()
                 try:
                     data = r.json()
                     olid = cls.OL._extract_olid_from_url(data.pop('key', u''),

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -514,20 +514,27 @@ class OpenLibrary(object):
                 if not olid:
                     if any([isbn, oclc, lccn, ocaid]):
                         if isbn:
+                            _id, value = ('isbn', isbn)
                             olid = cls.get_olid_by_isbn(isbn)
                         elif oclc:
+                            _id, value = ('oclc', oclc)
                             olid = cls.get_olid_by_oclc(oclc)
                         elif ocaid:
+                            _id, value = ('ocaid', ocaid)
                             olid = cls.get_olid_by_ocaid(ocaid)
                         else:
+                            _id, value = ('lccn', lccn)
                             olid = cls.get_olid_by_lccn(lccn)
                     else:
                         raise ValueError("Must supply valid olid, isbn, oclc, ocaid, or lccn")
 
-                err = lambda e: logger.exception("Error retrieving OpenLibrary " \
-                                                 "book: %s", e)
+                if olid is None:
+                    raise Exception("No olid found for %s = %s" % (_id, value))
+
                 url = cls.OL.base_url + '/books/%s.json' % olid
 
+                err = lambda e: logger.exception("Error retrieving OpenLibrary " \
+                                                 "book: %s", e)
                 @backoff.on_exception(on_giveup=err, **cls.OL.BACKOFF_KWARGS)
                 def _get_book_by_olid(url):
                     """Makes best effort to perform request w/ exponential backoff"""

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -68,9 +68,10 @@ class TestOpenLibrary(unittest.TestCase):
 
     @patch('requests.Session.get')
     def test_get_olid_notfound_by_isbn(self, mock_get):
-        mock_get.return_value.raise_for_status = raise_http_error
-        with pytest.raises(requests.HTTPError):
+        mock_get.json_data = {}
+        with pytest.raises(Exception) as e:
             self.ol.Edition.get(isbn='foobar')
+        assert 'No olid found for isbn = foobar' == str(e.value)
 
     @patch('requests.Session.get')
     def test_get_work_by_metadata(self, mock_get):

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -67,6 +67,12 @@ class TestOpenLibrary(unittest.TestCase):
                         "Expected olid %s, got %s" % (expected_olid, olid))
 
     @patch('requests.Session.get')
+    def test_get_olid_notfound_by_isbn(self, mock_get):
+        mock_get.return_value.raise_for_status = raise_for_status
+        with pytest.raises(requests.HTTPError):
+            self.ol.Edition.get(isbn='foobar')
+
+    @patch('requests.Session.get')
     def test_get_work_by_metadata(self, mock_get):
         doc = {
             "key":    u"/works/OL2514747W",

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -209,7 +209,7 @@ class TestOpenLibrary(unittest.TestCase):
         # (e.g. 404 or 500 HTTP response) it is not swallowed by the client.
         mock_get.return_value.raise_for_status = raise_for_status
         suffixes = {'edition': 'M', 'work': 'W', 'author': 'A'}
-        for _type, suffix in suffixes.iteritems():
+        for _type, suffix in suffixes.items():
             target = "OLnotfound%s" % suffix
             with pytest.raises(requests.HTTPError, message="HTTPError not raised for %s: %s" % (_type, target)):
                 r = self.ol.get(target)

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -47,7 +47,11 @@ def create_work(ol, **kwargs):
     return ol.Work(**defaults)
 
 def raise_http_error():
-    raise requests.HTTPError("test HTTPError")
+    r = requests.Response
+    # Non 4xx status will trigger backoff retries
+    r.status_code = 404
+    kwargs = {'response': r}
+    raise requests.HTTPError("test HTTPError", **kwargs)
 
 class TestOpenLibrary(unittest.TestCase):
 

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -46,7 +46,7 @@ def create_work(ol, **kwargs):
     defaults.update(kwargs)
     return ol.Work(**defaults)
 
-def raise_for_status():
+def raise_http_error():
     raise requests.HTTPError("test HTTPError")
 
 class TestOpenLibrary(unittest.TestCase):
@@ -68,7 +68,7 @@ class TestOpenLibrary(unittest.TestCase):
 
     @patch('requests.Session.get')
     def test_get_olid_notfound_by_isbn(self, mock_get):
-        mock_get.return_value.raise_for_status = raise_for_status
+        mock_get.return_value.raise_for_status = raise_http_error
         with pytest.raises(requests.HTTPError):
             self.ol.Edition.get(isbn='foobar')
 
@@ -207,7 +207,7 @@ class TestOpenLibrary(unittest.TestCase):
     def test_get_notfound(self, mock_get):
         # This tests that if requests.raise_for_status() raises an exception,
         # (e.g. 404 or 500 HTTP response) it is not swallowed by the client.
-        mock_get.return_value.raise_for_status = raise_for_status
+        mock_get.return_value.raise_for_status = raise_http_error
         suffixes = {'edition': 'M', 'work': 'W', 'author': 'A'}
         for _type, suffix in suffixes.items():
             target = "OLnotfound%s" % suffix

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -71,11 +71,10 @@ class TestOpenLibrary(unittest.TestCase):
                         "Expected olid %s, got %s" % (expected_olid, olid))
 
     @patch('requests.Session.get')
-    def test_get_olid_notfound_by_isbn(self, mock_get):
+    def test_get_olid_notfound_by_bibkey(self, mock_get):
         mock_get.json_data = {}
-        with pytest.raises(Exception) as e:
-            self.ol.Edition.get(isbn='foobar')
-        assert 'No olid found for isbn = foobar' == str(e.value)
+        edition = self.ol.Edition.get(isbn='foobar')
+        assert edition is None
 
     @patch('requests.Session.get')
     def test_get_work_by_metadata(self, mock_get):


### PR DESCRIPTION
This PR closes #60, #29, and #71 

## Description:

Uses `requests.raise_for_status()` http://docs.python-requests.org/en/master/_modules/requests/models/#Response.raise_for_status  to raise `HTTPError` on statuses greater 400, therefore preventing 404s and 50x responses creating blank or error items that can be saved.

Also, after some refactoring to add a single location to handle GET requests to OL, `_get_ol_response()`, this will attempt retries on non 4xx errors (e.g. 500s), but raise ``HTTPError` exceptions immediately on requests that result in Not Founds.

I am trying to make the logic so that a direct request for an OLID that results in a 404 Not Found raises a requests Exception, but anything that is _searched for_ by some term or other non-OL bibliographic key can return `None`.

There may still be other calls to `requests.session.get()` that should be moved to `_get_ol_response()` to take advantage of this `openlibrary` standard back-off and exception raising setup.

I have added tests for the common cases that were mentioned in the issues, but there isn't a test for the following case that can return `None`:

```
>>> from olclient.openlibrary import OpenLibrary
>>> ol = OpenLibrary()
>>> x = ol.get('OL123X')
>>> x is None
True
```
Which shows that a completely non-OLID like string returns `None`
This might be acceptable since any attempt to save raises an exception, which I believe is sufficient to prevent None items being saved.

```
>>> x.save()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'save'
```

