### PR TITLE
WIP: Allow openlibrary-client to auth with locally running openlibrary dev env

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -77,7 +77,7 @@ class OpenLibrary(object):
 
         response = _login(url, headers, data)
 
-        if 'Set-Cookie' not in response.headers:
+        if not self.session.cookies:
             raise ValueError("No cookie set")
 
     def validate(self, doc, schema_name):


### PR DESCRIPTION

@mekarpeles In order to make this work I'm using the following code locally:
```
from olclient.openlibrary import OpenLibrary

from collections import namedtuple
Credentials = namedtuple('Credentials', ['username', 'password'])
c = Credentials('openlibrary@example.com', 'admin123')
ol = OpenLibrary(base_url='http://localhost:8080', credentials=c)
```

There is probably a neater way to integrate this, but creating the `namedtuple` seemed the easiest way to interface with the existing methods.

The first commit in this PR "direct check for session cookie" is good though as it directly check whether we have a cookie. Previously it got confused with redirects, where the cookie had been set, but the last response in the redirect chain did not so the check failed, even though the session knew about the cookie.