### PR TITLE
Tidy requirements by removing transitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,6 @@ A reference client library for the Open Library API. Tested with Python 2.7, 3.5
 
 ## Installation
 
-As a prerequisite, openlibrary-client requires libssl-dev for the cryptography used in openssl. for Ubuntu kindly use the following command:
-
-```
-$ sudo apt install libssl-dev
-```
-
-For Fedora/RHEL, use the following command to install libssl-dev for crypptography used in openssl.
-```
-$ sudo dnf install openssl-dev
-```
-
 If you plan on doing MARC parsing, you'll need `yaz` (see: https://github.com/indexdata/yaz). Assuming Ubuntu/debian, you can install `yaz` via apt:
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,9 @@ backoff==1.3.1
 enum34==1.1.6
 idna==2.1
 ipaddress==1.0.16
-ndg-httpsclient==0.4.2
 pyasn1==0.1.9
 pycparser==2.14
 pymarc==3.1.5
-pyopenssl==17.5.0
 requests==2.20.0
 six==1.10.0
 jsonpickle==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 backoff==1.3.1
+internetarchive==1.8.1
+jsonpickle==0.9.3
+jsonschema==2.6.0
 pymarc==3.1.5
 requests==2.20.0
 six==1.10.0
-jsonpickle==0.9.3
-jsonschema==2.6.0
-internetarchive==1.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 backoff==1.3.1
-cffi==1.8.2
-cryptography==2.3.1
 enum34==1.1.6
 idna==2.1
 ipaddress==1.0.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
 backoff==1.3.1
-enum34==1.1.6
-idna==2.1
-ipaddress==1.0.16
-pyasn1==0.1.9
-pycparser==2.14
 pymarc==3.1.5
 requests==2.20.0
 six==1.10.0


### PR DESCRIPTION
This PR closes #117 
and closes #110 

I have tested this on under python 2.7 and 3 by install from the repo in fresh Ubuntu Xenial docker containers. Neither had `openssl-dev` or `libssl-dev` so I think these removals are safe, and will hopefully make installation simpler.