### PR TITLE
correct repo url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     ],
     author='Internet Archive',
     author_email='mek@archive.org',
-    url='https://github.com/ArchiveLabs/openlibrary-client',
+    url='https://github.com/internetarchive/openlibrary-client',
     include_package_data=True,
     packages=[
         'olclient',


### PR DESCRIPTION
This PR updates the package repo URL from
    url='https://github.com/ArchiveLabs/openlibrary-client',
to
    url='https://github.com/internetarchive/openlibrary-client',

Looks like ownership was transferred from https://github.com/ArchiveLabs to https://github.com/internetarchive for this repo. This updates the setup.py info to avoid the redirect.
