### PR TITLE
Travis CI: Add Python 3.7 to the testing in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+  allow_failures:
+    - python: "3.7"
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ os:
   - linux
 
 dist: trusty
-sudo: enabled
 
 python:
   - "2.7"
   - "3.5"
   - "3.6"
+
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 
 addons:
   apt:


### PR DESCRIPTION
[Travis are now recommending removing __sudo__](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)