### PR TITLE
Replace ValueError with prompt to configure on first usage

### DIFF
--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -68,16 +68,6 @@ def main():
     parser = argparser()
     args = parser.parse_args()
 
-    # prompt first time users to configure credentials for olclient
-    try:
-        if len(ia.config.get_config()) == 0:
-            raise ValueError("No configuration set")
-    except ValueError as e:
-        print("Seems like you haven't configured your olclient with credentials.\n"
-              "You can configure olclient using the following command:\n"
-              "$ol --configure --email <EMAIL>\n")
-        return parser.print_help()
-
     if args.configure:
         email = args.email or raw_input("Archive.org Email: ")
         if not email:
@@ -97,6 +87,18 @@ def main():
 
         config_tool.update(config)
         return "Successfully configured "
+
+    # prompt first time users to configure credentials for olclient
+    try:
+        if len(ia.config.get_config()) == 0:
+            print(ia.config.get_config())
+            raise ValueError("No configuration set")
+    except ValueError as e:
+        print("Seems like you haven't configured your olclient with credentials.\n"
+              "You can configure olclient using the following command:\n"
+              "$ol --configure --email <EMAIL>\n")
+        return parser.print_help()
+
     ol = OpenLibrary()
     if args.get_olid:
         return ol.Edition.get_olid_by_isbn(args.isbn)

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -68,6 +68,16 @@ def main():
     parser = argparser()
     args = parser.parse_args()
 
+    # prompt first time users to configure credentials for olclient
+    try:
+        if len(ia.config.get_config()) == 0:
+            raise ValueError("No configuration set")
+    except ValueError as e:
+        print("Seems like you haven't configured your olclient with credentials.\n"
+              "You can configure olclient using the following command:\n"
+              "$ol --configure --email <EMAIL>\n")
+        return parser.print_help()
+
     if args.configure:
         email = args.email or raw_input("Archive.org Email: ")
         if not email:
@@ -87,7 +97,6 @@ def main():
 
         config_tool.update(config)
         return "Successfully configured "
-
     ol = OpenLibrary()
     if args.get_olid:
         return ol.Edition.get_olid_by_isbn(args.isbn)

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -91,7 +91,6 @@ def main():
     # prompt first time users to configure credentials for olclient
     try:
         if len(ia.config.get_config()) == 0:
-            print(ia.config.get_config())
             raise ValueError("No configuration set")
     except ValueError as e:
         print("Seems like you haven't configured your olclient with credentials.\n"

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -84,7 +84,12 @@ class OpenLibrary(object):
         response = _login(url, headers, data)
 
         if not self.session.cookies:
-            raise ValueError("No cookie set")
+            try:
+                raise ValueError("No cookie set")
+            except ValueError as e:
+                print("Seems like you haven't configured your olclient with credentials.\n"\
+                      "You can configure olclient using the following command:\n"\
+                      "$ol --configure --email <EMAIL>\n")
 
     def validate(self, doc, schema_name):
         """Validates a doc's json representation against

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -84,12 +84,7 @@ class OpenLibrary(object):
         response = _login(url, headers, data)
 
         if not self.session.cookies:
-            try:
-                raise ValueError("No cookie set")
-            except ValueError as e:
-                print("Seems like you haven't configured your olclient with credentials.\n"\
-                      "You can configure olclient using the following command:\n"\
-                      "$ol --configure --email <EMAIL>\n")
+            raise ValueError("No cookie set")
 
     def validate(self, doc, schema_name):
         """Validates a doc's json representation against


### PR DESCRIPTION
This PR closes #119 

Previously CLI invocation missing config files would mean a `ValueError("No cookie set")` being flagged.
This PR covers this behaviour by the use of a try-except block that allows the handling of the `ValueError("No cookie set")` by prompting the user with instructions(configure option example) to configure the olclient and displaying the general usage of the ol command. 

The prompt displayed is:

> Seems like you haven't configured your olclient with credentials.
You can configure using the following command:
$ol --configure --email <EMAIL>
