### PR TITLE
Replace ValueError with prompt to configure on first usage

### DIFF
--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -90,7 +90,7 @@ def main():
 
     # prompt first time users to configure credentials for olclient
     try:
-        if len(ia.config.get_config()) == 0:
+        if not len(ia.config.get_config()):
             raise ValueError("No configuration set")
     except ValueError as e:
         print("Seems like you haven't configured your olclient with credentials.\n"

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -88,17 +88,18 @@ def main():
         config_tool.update(config)
         return "Successfully configured "
 
-    # prompt first time users to configure credentials for olclient
+    # prompt first time users to configure their OpenLibrary credentials
     try:
-        if not len(ia.config.get_config()):
-            raise ValueError("No configuration set")
+        ol = OpenLibrary()
     except ValueError as e:
-        print("Seems like you haven't configured your olclient with credentials.\n"
+        if str(e) == 'No cookie set':
+            print("Seems like you haven't configured your olclient with credentials.\n"
               "You can configure olclient using the following command:\n"
               "$ol --configure --email <EMAIL>\n")
-        return parser.print_help()
+            return parser.print_help()
+        else:
+            raise
 
-    ol = OpenLibrary()
     if args.get_olid:
         return ol.Edition.get_olid_by_isbn(args.isbn)
     elif args.get_book:

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -88,6 +88,16 @@ def main():
         config_tool.update(config)
         return "Successfully configured "
 
+    # prompt first time users to configure credentials for olclient
+    try:
+        if len(ia.config.get_config()) == 0:
+            raise ValueError("No configuration set")
+    except ValueError as e:
+        print("Seems like you haven't configured your olclient with credentials.\n"
+              "You can configure olclient using the following command:\n"
+              "$ol --configure --email <EMAIL>\n")
+        return parser.print_help()
+
     ol = OpenLibrary()
     if args.get_olid:
         return ol.Edition.get_olid_by_isbn(args.isbn)


### PR DESCRIPTION
This PR closes #119 

## Description:
Previously CLI invocation missing config files would mean a `ValueError("No cookie set")` being flagged.
This PR covers this behaviour by the use of a try-except block included in `olclient/cli.py` which prompts the user with instructions(configure option example) to configure the olclient and displaying the general usage of the ol command. 

The prompt displayed is:

> Seems like you haven't configured your olclient with credentials.
You can configure using the following command:
$ol --configure --email \<EMAIL\>