### PR TITLE
No rejection of author data with comma during retrieval

### DIFF
--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -90,7 +90,7 @@ def main():
 
     # prompt first time users to configure credentials for olclient
     try:
-        if len(ia.config.get_config()) == 0:
+        if not len(ia.config.get_config()):
             raise ValueError("No configuration set")
     except ValueError as e:
         print("Seems like you haven't configured your olclient with credentials.\n"

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -88,17 +88,18 @@ def main():
         config_tool.update(config)
         return "Successfully configured "
 
-    # prompt first time users to configure credentials for olclient
+    # prompt first time users to configure their OpenLibrary credentials
     try:
-        if not len(ia.config.get_config()):
-            raise ValueError("No configuration set")
+        ol = OpenLibrary()
     except ValueError as e:
-        print("Seems like you haven't configured your olclient with credentials.\n"
+        if str(e) == 'No cookie set':
+            print("Seems like you haven't configured your olclient with credentials.\n"
               "You can configure olclient using the following command:\n"
               "$ol --configure --email <EMAIL>\n")
-        return parser.print_help()
+            return parser.print_help()
+        else:
+            raise
 
-    ol = OpenLibrary()
     if args.get_olid:
         return ol.Edition.get_olid_by_isbn(args.isbn)
     elif args.get_book:

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -88,6 +88,16 @@ def main():
         config_tool.update(config)
         return "Successfully configured "
 
+    # prompt first time users to configure credentials for olclient
+    try:
+        if len(ia.config.get_config()) == 0:
+            raise ValueError("No configuration set")
+    except ValueError as e:
+        print("Seems like you haven't configured your olclient with credentials.\n"
+              "You can configure olclient using the following command:\n"
+              "$ol --configure --email <EMAIL>\n")
+        return parser.print_help()
+
     ol = OpenLibrary()
     if args.get_olid:
         return ol.Edition.get_olid_by_isbn(args.isbn)

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -1037,6 +1037,12 @@ class Results(object):
             work_olid = OpenLibrary._extract_olid_from_url(key, "works")
             edition_olids = edition_key
 
+            # clean author_names to compose result object:
+            # remove comma in an author's name if its not None only while retrieving data
+            if author_name:
+                for i in range(len(author_name)):
+                    author_name[i] = author_name[i].replace(',','')
+
             self.title = title
             self.subtitle = subtitle
             self.subjects = subject


### PR DESCRIPTION
This PR closes #118 

## Description:
Check the commas present in the author name in the retrieved data from the respective endpoint(associated with the function that initiates the `Results.Document` object creation) before the creation of the Author object. 
Doing this check before the creation of the `Author` object is necessary to avoid triggering the comma check in the `Author`'s `__init__` which is in place to avoid author names with commas being written into the database. It was this unintended check on data already in the database(while retrieving) which was causing the issue 