### PR TITLE
Don't reject author data with comma during retrieval 

### DIFF
--- a/olclient/common.py
+++ b/olclient/common.py
@@ -65,19 +65,15 @@ class Author(Entity):
 
     def __init__(self, name, identifiers=None, **kwargs):
         super(Author, self).__init__(identifiers=identifiers)
-        self.name = self._validate_author_name(name)
+        if ',' in name: 
+            raise ValueError("{} is not a valid Author name - No commas allowed (first last)".format(name))
+        self.name = name
 
         for kwarg in kwargs:
             setattr(self, kwarg, kwargs[kwarg])
 
     def __repr__(self):
         return '<%s %s>' % (str(self.__class__)[1:-1], self.__dict__)
-
-    @staticmethod
-    def _validate_author_name(name):
-        if ',' in name:
-            raise ValueError("{} is not a valid Author name - No commas allowed (first last)".format(name))
-        return name
 
 
 class Book(Entity):

--- a/olclient/common.py
+++ b/olclient/common.py
@@ -65,15 +65,19 @@ class Author(Entity):
 
     def __init__(self, name, identifiers=None, **kwargs):
         super(Author, self).__init__(identifiers=identifiers)
-        if ',' in name: 
-            raise ValueError("{} is not a valid Author name - No commas allowed (first last)".format(name))
-        self.name = name
+        self.name = self._validate_author_name(name)
 
         for kwarg in kwargs:
             setattr(self, kwarg, kwargs[kwarg])
 
     def __repr__(self):
         return '<%s %s>' % (str(self.__class__)[1:-1], self.__dict__)
+
+    @staticmethod
+    def _validate_author_name(name):
+        if ',' in name:
+            raise ValueError("{} is not a valid Author name - No commas allowed (first last)".format(name))
+        return name
 
 
 class Book(Entity):

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -1037,6 +1037,12 @@ class Results(object):
             work_olid = OpenLibrary._extract_olid_from_url(key, "works")
             edition_olids = edition_key
 
+            # clean author_names to compose result object:
+            # remove comma in an author's name if its not None only while retrieving data
+            if author_name:
+                for i in range(len(author_name)):
+                    author_name[i] = author_name[i].replace(',', '')
+
             self.title = title
             self.subtitle = subtitle
             self.subjects = subject

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -1043,7 +1043,7 @@ class Results(object):
             # XXX test that during the zip, author_name and author_key
             # correspond to each other one-to-one, in order
             self.authors = [
-                {'name' : name, 'olid' : author_olid}
+                {'name': name, 'olid': author_olid}
                 for (name, author_olid) in
                 zip(author_name or [], author_key or [])]
             self.publishers = publisher

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -627,10 +627,6 @@ class OpenLibrary(object):
                 self.olid = olid
                 super(Author, self).__init__(name, **author_kwargs)
 
-            @staticmethod
-            def _validate_author_name(name):
-                return name
-
             def json(self):
                 """Returns a dict JSON representation of an OL Author suitable
                 for saving back to Open Library via its APIs.
@@ -1049,7 +1045,7 @@ class Results(object):
             # XXX test that during the zip, author_name and author_key
             # correspond to each other one-to-one, in order
             self.authors = [
-                self.OL.Author(olid=author_olid, name=name)
+                {'name' : name, 'olid' : author_olid}
                 for (name, author_olid) in
                 zip(author_name or [], author_key or [])]
             self.publishers = publisher

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -627,6 +627,10 @@ class OpenLibrary(object):
                 self.olid = olid
                 super(Author, self).__init__(name, **author_kwargs)
 
+            @staticmethod
+            def _validate_author_name(name):
+                return name
+
             def json(self):
                 """Returns a dict JSON representation of an OL Author suitable
                 for saving back to Open Library via its APIs.
@@ -1008,6 +1012,8 @@ class Results(object):
     class Document(object):
         """An aggregate OpenLibrary Work summarizing all Editions of a Book"""
 
+        OL = OpenLibrary()
+
         def __init__(self, key, title=u"", subtitle=None, subject=None,
                      author_name=u"", author_key=None, edition_key=None,
                      language="", publisher=None, publish_date=None,
@@ -1037,19 +1043,13 @@ class Results(object):
             work_olid = OpenLibrary._extract_olid_from_url(key, "works")
             edition_olids = edition_key
 
-            # clean author_names to compose result object:
-            # remove comma in an author's name if its not None only while retrieving data
-            if author_name:
-                for i in range(len(author_name)):
-                    author_name[i] = author_name[i].replace(',', '')
-
             self.title = title
             self.subtitle = subtitle
             self.subjects = subject
             # XXX test that during the zip, author_name and author_key
             # correspond to each other one-to-one, in order
             self.authors = [
-                common.Author(name=name, identifiers={u'olid': [author_olid]})
+                self.OL.Author(olid=author_olid, name=name)
                 for (name, author_olid) in
                 zip(author_name or [], author_key or [])]
             self.publishers = publisher

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -1008,8 +1008,6 @@ class Results(object):
     class Document(object):
         """An aggregate OpenLibrary Work summarizing all Editions of a Book"""
 
-        OL = OpenLibrary()
-
         def __init__(self, key, title=u"", subtitle=None, subject=None,
                      author_name=u"", author_key=None, edition_key=None,
                      language="", publisher=None, publish_date=None,


### PR DESCRIPTION
This PR closes #118 

## Description:
Check the commas present in the author name in the retrieved data from the respective endpoint(associated with the function that initiates the `Results.Document` object creation) before the creation of the Author object. 
Doing this check before the creation of the `Author` object is necessary to avoid triggering the comma check in the `Author`'s `__init__` which is in place to avoid author names with commas being written into the database. It was this unintended check on data already in the database(while retrieving) which was causing the issue 
