### PR TITLE
Feature addition to list the works of a particular Author

### DIFF
--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -39,7 +39,7 @@ def argparser():
                         help='Configure ol client with credentials')
     parser.add_argument('--get-work', action='store_true',
                         help='Get a work by --title, --olid')
-    parser.add_argument('--get-works-of-author', action='store_true',
+    parser.add_argument('--get-author-works', action='store_true',
                         help='Get a works by an author')
     parser.add_argument('--get-book', action='store_true',
                         help='Get a book by --isbn, --olid')
@@ -116,11 +116,11 @@ def main():
             return jsonpickle.encode(ol.Work.get(args.olid))
         elif args.title:
             return jsonpickle.encode(ol.Work.search(args.title))
-    elif args.get_works_of_author:
+    elif args.get_author_works:
         if args.olid:
-            return jsonpickle.encode(ol.Author.get_works(args.olid))
+            return jsonpickle.encode(ol.Author.get(args.olid).works())
         elif args.author:
-            return jsonpickle.encode(ol.Author.get_works(ol.Author.get_olid_by_name(args.author)))
+            return jsonpickle.encode(ol.Author.get(ol.Author.get_olid_by_name(args.author)).works())
     elif args.create:
         data = json.loads(args.create)
         title = data.pop('title')

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -40,7 +40,7 @@ def argparser():
     parser.add_argument('--get-work', action='store_true',
                         help='Get a work by --title, --olid')
     parser.add_argument('--get-author-works', action='store_true',
-                        help='Get a works by an author')
+                        help='Get a works of an author providing author\'s --olid, --author-name ')
     parser.add_argument('--get-book', action='store_true',
                         help='Get a book by --isbn, --olid')
     parser.add_argument('--get-olid', action='store_true',
@@ -53,7 +53,7 @@ def argparser():
                         help='Create a new work from json')
     parser.add_argument('--title', default=None,
                         help="Specify a title as an argument")
-    parser.add_argument('--author', default=None,
+    parser.add_argument('--author-name', default=None,
                         help="Specify an author as an argument")
     parser.add_argument('--baseurl', default='https://openlibrary.org',
                         help="Which OL backend to use")
@@ -119,8 +119,8 @@ def main():
     elif args.get_author_works:
         if args.olid:
             return jsonpickle.encode(ol.Author.get(args.olid).works())
-        elif args.author:
-            return jsonpickle.encode(ol.Author.get(ol.Author.get_olid_by_name(args.author)).works())
+        elif args.author_name:
+            return jsonpickle.encode(ol.Author.get(ol.Author.get_olid_by_name(args.author_name)).works())
     elif args.create:
         data = json.loads(args.create)
         title = data.pop('title')

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -39,6 +39,8 @@ def argparser():
                         help='Configure ol client with credentials')
     parser.add_argument('--get-work', action='store_true',
                         help='Get a work by --title, --olid')
+    parser.add_argument('--get-works-of-author', action='store_true',
+                        help='Get a works by an author')
     parser.add_argument('--get-book', action='store_true',
                         help='Get a book by --isbn, --olid')
     parser.add_argument('--get-olid', action='store_true',
@@ -51,6 +53,8 @@ def argparser():
                         help='Create a new work from json')
     parser.add_argument('--title', default=None,
                         help="Specify a title as an argument")
+    parser.add_argument('--author', default=None,
+                        help="Specify an author as an argument")
     parser.add_argument('--baseurl', default='https://openlibrary.org',
                         help="Which OL backend to use")
     parser.add_argument('--email', default=None,
@@ -112,6 +116,11 @@ def main():
             return jsonpickle.encode(ol.Work.get(args.olid))
         elif args.title:
             return jsonpickle.encode(ol.Work.search(args.title))
+    elif args.get_works_of_author:
+        if args.olid:
+            return jsonpickle.encode(ol.Author.get_works(args.olid))
+        elif args.author:
+            return jsonpickle.encode(ol.Author.get_works(ol.Author.get_olid_by_name(args.author)))
     elif args.create:
         data = json.loads(args.create)
         title = data.pop('title')

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -687,6 +687,42 @@ class OpenLibrary(object):
                     **data)
 
             @classmethod
+            def get_works(cls, olid, limit=50):
+                """Returns a list of OpenLibrary Works associated with an OpenLibrary Author.
+
+                Args:
+                    olid (unicode) - OpenLibrary ID for author to search within
+                                    Open Library's database of authors to retrieve his Works.
+                    name (unicode) - name of an Author to search for within OpenLibrary.
+                    limit (integer) - number of Author's Works to return.
+
+                Returns:
+                    A (list) of Works from the OpenLibrary associated with the
+                    Author.
+
+                Usage:
+                    >>> from olclient.openlibrary import OpenLibrary
+                    >>> ol = OpenLibrary()
+                    >>> ol.Author.get_works('OL39307A')
+                    or
+                    >>> ol.Author.get_works('OL39307A', 5)
+                    or
+                    >>> ol.Author.get_works(ol.Author.get_olid_by_name('Dan Brown'))
+                """
+                path = '/authors/%s/works.json' % olid
+
+                if limit:
+                    # by default the limit is set in the function definition
+                    path += '/?limit=%s' % limit
+
+                try:
+                    response = cls.OL._get_ol_response(path)
+                    return response.json()
+                except Exception as e:
+                    logger.exception(e)
+                    raise Exception("Author API failed to return json")
+
+            @classmethod
             def search(cls, name, limit=1):
                 """Finds a list of OpenLibrary authors with similar names to the
                 search query using the Author auto-complete API.

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -656,6 +656,49 @@ class OpenLibrary(object):
                 url = self.OL.base_url + '/authors/%s.json' % self.olid
                 return self.OL.session.put(url, json.dumps(body))
 
+            def works(self, limit=50, offset=0):
+                """Returns a list of OpenLibrary Works associated with an OpenLibrary Author.
+
+                Args:
+                    olid (unicode) - OpenLibrary ID for author to search within
+                                    Open Library's database of authors to retrieve his Works.
+                    name (unicode) - name of an Author to search for within OpenLibrary.
+                    limit (integer) - number of Author's Works to return.
+                    offset (integer) - offset number to aid pagination.
+                Returns:
+                    A (list) of Works from the OpenLibrary associated with the
+                    Author.
+
+                Usage:
+                    >>> from olclient.openlibrary import OpenLibrary
+                    >>> ol = OpenLibrary()
+                    >>> ol.Author.get('OL39307A').works()
+                    or
+                    >>> ol.Author.get('OL39307A').works(limit=20)# to obtain the first 20 works of the author
+                    >>> ol.Author.get('OL39307A').works(limit=20, offset=20)# to obtain the next 20 works of the author
+                    or
+                    >>> author_obj = ol.Author.get(ol.Author.get_olid_by_name('Dan Brown'))
+                    >>> author_obj.works()
+                    or
+                    >>> ol.Author.get(ol.Author.get_olid_by_name('Dan Brown')).works()
+                """
+                path = '/authors/%s/works.json' % self.olid
+
+                if limit:
+                    # by default the limit is set in the function definition
+                    path += '/?limit=%s' % limit
+
+                if offset:
+                    # by default the offset is set in the function definition
+                    path += '&offset=%s' % offset
+
+                try:
+                    response = self.OL._get_ol_response(path)
+                    return response.json()
+                except Exception as e:
+                    logger.exception(e)
+                    raise Exception("Author API failed to return json")
+
             @classmethod
             def get(cls, olid):
                 """Retrieves an OpenLibrary Author by author_olid
@@ -685,42 +728,6 @@ class OpenLibrary(object):
                     olid, name=data.pop('name', u''),
                     bio=OpenLibrary.get_text_value(data.pop('bio', None)),
                     **data)
-
-            @classmethod
-            def get_works(cls, olid, limit=50):
-                """Returns a list of OpenLibrary Works associated with an OpenLibrary Author.
-
-                Args:
-                    olid (unicode) - OpenLibrary ID for author to search within
-                                    Open Library's database of authors to retrieve his Works.
-                    name (unicode) - name of an Author to search for within OpenLibrary.
-                    limit (integer) - number of Author's Works to return.
-
-                Returns:
-                    A (list) of Works from the OpenLibrary associated with the
-                    Author.
-
-                Usage:
-                    >>> from olclient.openlibrary import OpenLibrary
-                    >>> ol = OpenLibrary()
-                    >>> ol.Author.get_works('OL39307A')
-                    or
-                    >>> ol.Author.get_works('OL39307A', 5)
-                    or
-                    >>> ol.Author.get_works(ol.Author.get_olid_by_name('Dan Brown'))
-                """
-                path = '/authors/%s/works.json' % olid
-
-                if limit:
-                    # by default the limit is set in the function definition
-                    path += '/?limit=%s' % limit
-
-                try:
-                    response = cls.OL._get_ol_response(path)
-                    return response.json()
-                except Exception as e:
-                    logger.exception(e)
-                    raise Exception("Author API failed to return json")
 
             @classmethod
             def search(cls, name, limit=1):

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -54,6 +54,10 @@ class OpenLibrary(object):
         'max_tries': 5
     }
 
+    # constants to aid works.json API request's pagination
+    WORKS_LIMIT = 50
+    WORKS_PAGINATION_OFFSET = 0
+
     def __init__(self, credentials=None, base_url=u'https://openlibrary.org'):
         self.session = requests.Session()
         self.base_url = base_url
@@ -656,7 +660,7 @@ class OpenLibrary(object):
                 url = self.OL.base_url + '/authors/%s.json' % self.olid
                 return self.OL.session.put(url, json.dumps(body))
 
-            def works(self, limit=50, offset=0):
+            def works(self, limit=OL.WORKS_LIMIT, offset=OL.WORKS_PAGINATION_OFFSET):
                 """Returns a list of OpenLibrary Works associated with an OpenLibrary Author.
 
                 Args:
@@ -684,13 +688,12 @@ class OpenLibrary(object):
                 """
                 path = '/authors/%s/works.json' % self.olid
 
-                if limit:
-                    # by default the limit is set in the function definition
-                    path += '/?limit=%s' % limit
+                # check to prevent 'None' value
+                limit = limit or self.OL.WORKS_LIMIT
+                offset = offset or self.OL.WORKS_PAGINATION_OFFSET
 
-                if offset:
-                    # by default the offset is set in the function definition
-                    path += '&offset=%s' % offset
+                # including limit and offset querystrings to the url
+                path += '/?limit=%s&offset=%s' % (limit, offset)
 
                 try:
                     response = self.OL._get_ol_response(path)


### PR DESCRIPTION
This PR closes #131

## Description:
The newly added `get_works` function is a wrapper to access the following endpoint
```
https://openlibrary.org/authors/<Author OLID>/works.json
```
which returns the list of `Works` associated with an `Author` in JSON format.
All the information field present for a Work is returned.

The following is the function signature information for `get_works` function:

> **Args**:
                    _olid_ (unicode) - OpenLibrary ID for author to search within
                                    Open Library's database of authors to retrieve his Works.
                    _name_ (unicode) - name of an Author to search for within OpenLibrary.
                    _limit_ (integer) - number of Author's Works to return.
                **Returns:**
                    A (list) of Works from the OpenLibrary associated with the
                    Author.
