### PR TITLE
don't reject existing OL author names with commas

### DIFF
--- a/olclient/common.py
+++ b/olclient/common.py
@@ -65,8 +65,7 @@ class Author(Entity):
 
     def __init__(self, name, identifiers=None, **kwargs):
         super(Author, self).__init__(identifiers=identifiers)
-        if ',' in name: 
-            raise ValueError("{} is not a valid Author name - No commas allowed (first last)".format(name))
+        self._validate_name(name)
         self.name = name
 
         for kwarg in kwargs:
@@ -74,6 +73,11 @@ class Author(Entity):
 
     def __repr__(self):
         return '<%s %s>' % (str(self.__class__)[1:-1], self.__dict__)
+
+    @staticmethod
+    def _validate_name(name):
+        if ',' in name:
+            raise ValueError("{} is not a valid Author name - No commas allowed (first last)".format(name))
 
 
 class Book(Entity):

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -631,6 +631,11 @@ class OpenLibrary(object):
                 self.olid = olid
                 super(Author, self).__init__(name, **author_kwargs)
 
+            @staticmethod
+            def _validate_name(name):
+                """Don't reject existing author names from Open Library."""
+                return
+
             def json(self):
                 """Returns a dict JSON representation of an OL Author suitable
                 for saving back to Open Library via its APIs.


### PR DESCRIPTION
 directly when loading authors

Rejecting Author names with commas when creating new authors (via common.Author) is appropriate (with some caveats that have been mentioned elsewhere) since OL standard requires natural name order, but this should _not_ prevent the ol-client from loading existing authors with commas. Otherwise, how could they be fixed using the ol-client?

This PR fixes this problem. Previously 
```
from olclient.openlibrary import OpenLibrary
ol = OpenLibrary()
a = ol.get('OL69006A')
```
resulted in:
```
ValueError: Smith, John is not a valid Author name - No commas allowed (first last)
```
and `a` set to `None`

After this PR, the `Smith, John` author can be loaded normally and either inspected without modification, or corrected etc.


## Description:
