### PR TITLE
Support Py37 & Py38 and drop EOLed Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,18 @@
+os: linux
+
 language: python
-
-os:
-  - linux
-
-dist: trusty
 
 python:
   - "2.7"
   - "3.5"
   - "3.6"
-
-matrix:
-  include:
-    - python: "3.7"
-      dist: xenial # required for Python >= 3.7 (travis-ci/travis-ci#9069)
-  allow_failures:
-    - python: "3.7"
+  - "3.7"
+  - "3.8"
 
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://ftp.indexdata.dk/ubuntu trusty main'
+    - sourceline: 'deb http://ftp.indexdata.dk/ubuntu xenial main'
       key_url: http://ftp.indexdata.dk/debian/indexdata.asc
     packages:
     - yaz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 os: linux
-
-dist:
-  - trusty
-  - xenial
-  - bionic
+dist: bionic
 
 language: python
-
 python:
   - "2.7"
   - "3.5"
@@ -22,8 +17,7 @@ addons:
     packages:
     - yaz
 
-before_install:
-  - yaz-marcdump -V
+before_install: yaz-marcdump -V
 
 install: pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 os: linux
 
+dist:
+  - trusty
+  - xenial
+  - bionic
+
 language: python
 
 python:
@@ -12,7 +17,7 @@ python:
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://ftp.indexdata.dk/ubuntu xenial main'
+    - sourceline: 'deb http://ftp.indexdata.dk/ubuntu $TRAVIS_DIST main'
       key_url: http://ftp.indexdata.dk/debian/indexdata.asc
     packages:
     - yaz

--- a/olclient/common.py
+++ b/olclient/common.py
@@ -82,7 +82,7 @@ class Author(Entity):
 
 class Book(Entity):
     """Organizational model for standardizing MARC, OpenLibrary, and other
-    sources into a uniform format so they can be programatically
+    sources into a uniform format so they can be programmatically
     ingested and compared for similarity.
     """
 

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -986,7 +986,7 @@ class OpenLibrary(object):
     def _generate_url_from_olid(self, olid):
         """Returns the .json url for an olid (str)"""
         ol_paths = {'OL..A': 'authors', 'OL..M': 'books', 'OL..W': 'works'}
-        kind = re.sub('\d+', '..', olid)
+        kind = re.sub(r'\d+', '..', olid)
         return "%s/%s/%s.json" % (self.base_url, ol_paths[kind], olid)
 
     @staticmethod
@@ -1003,7 +1003,7 @@ class OpenLibrary(object):
     @staticmethod
     def get_type(olid):
         ol_types = {'OL..A': 'author', 'OL..M': 'book', 'OL..W': 'work'}
-        kind = re.sub('\d+', '..', olid)
+        kind = re.sub(r'\d+', '..', olid)
         try:
             return ol_types[kind]
         except KeyError:

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -122,7 +122,7 @@ class OpenLibrary(object):
         Uses the Open Library save_many API endpoint to
         write any number or combination of documents (Edition, Work, or Author)
         back to Open Library.
-        Uses HTTP Exension Framework custom headers (RFC 2774).
+        Uses HTTP Extension Framework custom headers (RFC 2774).
         """
         headers = {
             'Opt': '"http://openlibrary.org/dev/docs/api"; ns=42',

--- a/olclient/utils.py
+++ b/olclient/utils.py
@@ -37,7 +37,10 @@ def chunks(seq, chunk_size):
     """
     def take(seq, n):
         for i in range(n):
-            yield next(seq)
+            try:
+                yield next(seq)
+            except StopIteration:
+                return
 
     if not hasattr(seq, 'next'):
         seq = iter(seq)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ jsonpickle==0.9.3
 jsonschema==2.6.0
 pymarc==3.1.5
 requests[security]==2.23.0
-six==1.10.0
+six==1.14.0

--- a/tests/test_marc.py
+++ b/tests/test_marc.py
@@ -33,7 +33,7 @@ class TestMARC(unittest.TestCase):
         with open(example_path('line_marc.txt')) as line_marc:
             bin_marc = MARC.convert(line_marc.read())
             with open(example_path('bin_marc.mrc'), 'rb') as expected_bin_marc:
-                self.assertEquals(bin_marc, expected_bin_marc.read(),
+                self.assertEqual(bin_marc, expected_bin_marc.read(),
                                 "output of convert (line->bin) "
                                 "didn't match example file")
 
@@ -42,7 +42,7 @@ class TestMARC(unittest.TestCase):
         with open(example_path('line_marc.txt')) as line_marc:
             data = MARC.line_to_dict(line_marc.read())
             expected_title = "Wege aus einer kranken Gesellschaft"
-            self.assertEquals(data['title'], expected_title,
+            self.assertEqual(data['title'], expected_title,
                             "Expected title %s, got %s"
                             % (expected_title, data['title']))
 
@@ -50,7 +50,7 @@ class TestMARC(unittest.TestCase):
         with open(os.path.join(EXAMPLES_PATH, 'line_marc.txt')) as line_marc:
             book = MARC.line_to_book(line_marc.read())
             expected_title = "Wege aus einer kranken Gesellschaft"
-            self.assertEquals(book.title, expected_title,
+            self.assertEqual(book.title, expected_title,
                             "Expected title %s, got title %s"
                             % (expected_title, book.title))
 
@@ -59,7 +59,7 @@ class TestMARC(unittest.TestCase):
             bin_marc = MARC.convert(line_marc.read())
             book = MARC.to_book(bin_marc)
             expected_title = "Wege aus einer kranken Gesellschaft"
-            self.assertEquals(book.title, expected_title,
+            self.assertEqual(book.title, expected_title,
                             "Expected title %s, got title %s"
                             % (expected_title, book.title))
 
@@ -79,13 +79,13 @@ class TestMARC(unittest.TestCase):
         with open(line_marc_file) as line_marc:
             bin_marc = MARC.convert(line_marc.read())
             with open(bin_marc_file, 'rb') as expected_bin_marc:
-                self.assertEquals(bin_marc, expected_bin_marc.read(),
+                self.assertEqual(bin_marc, expected_bin_marc.read(),
                                 "Binary MARC didn't match expected " \
                                 "unicode content")
                 marcs = pymarc.MARCReader(bin_marc, hide_utf8_warnings=True,
                                           force_utf8=True, utf8_handling='ignore')
                 marc = six.next(marcs)
-                self.assertEquals(marc.author(),
+                self.assertEqual(marc.author(),
                                 u'ƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƘƙƚƛƜƝƞƟƠơ '\
                                 '1900-1980 Verfasser (DE-588)118536389 aut',
                                 "Line MARC title didn't match pymarc title")
@@ -96,9 +96,9 @@ class TestMARC(unittest.TestCase):
             book = MARC.line_to_book(line_marc.read())
             expected_author = u'ƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƘƙƚƛƜƝƞƟƠơ'
             expected_title = u'ΛΦϞЌЍЖ⁁⅀∰   ﬢﬡ－中英字典こんにちはß'
-            self.assertEquals(book.primary_author.name, expected_author,
+            self.assertEqual(book.primary_author.name, expected_author,
                             "Expected author %s, got author %s" % \
                             (expected_author, book.primary_author.name))
-            self.assertEquals(book.primary_author.name, expected_author,
+            self.assertEqual(book.primary_author.name, expected_author,
                             "Expected title %s, got title %s" % \
                             (expected_title, book.title))

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -286,7 +286,7 @@ class TestFullEditionGet(unittest.TestCase):
             call().raise_for_status(),
             call().json()
         ])
-        self.assertEquals(actual, self.expected,
+        self.assertEqual(actual, self.expected,
                         "Data didn't match for ISBN lookup: \n%s\n\nversus:\n\n %s" % (actual, self.expected))
 
     def test_load_by_olid(self, mock_get):
@@ -301,7 +301,7 @@ class TestFullEditionGet(unittest.TestCase):
             call().raise_for_status(),
             call().json()
         ])
-        self.assertEquals(actual, self.expected,
+        self.assertEqual(actual, self.expected,
                         "Data didn't match for olid lookup: %s\n\nversus:\n\n %s" % (actual, self.expected))
 
 class TestTextType(unittest.TestCase):
@@ -318,24 +318,24 @@ class TestTextType(unittest.TestCase):
         edition = create_edition(self.ol, **self.strings)
         self.assertIsNone(edition.validate())
         self.assertIn('type', edition.json()['description'])
-        self.assertEquals(edition.json()['description']['value'], "A String Description")
+        self.assertEqual(edition.json()['description']['value'], "A String Description")
 
     def test_edition_text_type(self):
         edition = create_edition(self.ol, **self.texts)
         self.assertIsNone(edition.validate())
         self.assertIsInstance(edition.description, string_types)
         self.assertIn('type', edition.json()['description'])
-        self.assertEquals(edition.json()['description']['value'], "A Text Description")
+        self.assertEqual(edition.json()['description']['value'], "A Text Description")
 
     def test_work_text_type_from_string(self):
         work = create_work(self.ol, **self.strings)
         self.assertIsNone(work.validate())
         self.assertIn('type', work.json()['description'])
-        self.assertEquals(work.json()['description']['value'], "A String Description")
+        self.assertEqual(work.json()['description']['value'], "A String Description")
 
     def test_work_text_type(self):
         work = create_work(self.ol, **self.texts)
         self.assertIsNone(work.validate())
         self.assertIsInstance(work.description, string_types)
         self.assertIn('type', work.json()['description'])
-        self.assertEquals(work.json()['description']['value'], "A Text Description")
+        self.assertEqual(work.json()['description']['value'], "A Text Description")

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -215,8 +215,9 @@ class TestOpenLibrary(unittest.TestCase):
         suffixes = {'edition': 'M', 'work': 'W', 'author': 'A'}
         for _type, suffix in suffixes.items():
             target = "OLnotfound%s" % suffix
-            with pytest.raises(requests.HTTPError, message="HTTPError not raised for %s: %s" % (_type, target)):
+            with pytest.raises(requests.HTTPError):
                 r = self.ol.get(target)
+                pytest.fail("HTTPError not raised for %s: %s" % (_type, target))
 
     @patch('requests.Session.post')
     def test_save_many(self, mock_post):


### PR DESCRIPTION
## Description:
* Add Python 3.7 and 3.8 to the testing
* Travis CI: Drop support for EOLed Ubuntu Trusty
* PEP 479: Fix StopIteration for Python >= 3.7
    * https://stackoverflow.com/questions/51700960/runtimeerror-generator-raised-stopiteration-every-time-i-try-to-run-app
* unittest.TestCase.assertEquals() -->assertEqual()
* Fix DeprecationWarning: invalid escape sequence \d
* Fix pytest deprecation: "message" parameter of pytest.raises
    * https://docs.pytest.org/en/latest/deprecations.html#message-parameter-of-pytest-raises
* Fix typos found by codespell
    *  programatically --> programmatically
    *  Exension --> Extension 
