### PR TITLE
Don't need so many Python 3 versions on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ dist: bionic
 language: python
 python:
   - "2.7"
-  - "3.5"
-  - "3.6"
   - "3.7"
   - "3.8"
 


### PR DESCRIPTION
Current and one point version back should be sufficient.