### PR TITLE
Upgrade pymarc on Python 3 only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ backoff==1.10.0
 internetarchive==1.9.0
 jsonpickle==0.9.3
 jsonschema==3.2.0
-pymarc==3.2.0
+pymarc==3.2.0; python_version < '3.0'
+pymarc==4.0.0; python_version >= '3.0'
 requests[security]==2.23.0
 simplejson==3.16
 six==1.14.0


### PR DESCRIPTION
Fixes #155

https://gitlab.com/pymarc/pymarc/-/tags

The Python type hints that we are putting into pymarc should improve our ability to detect type errors in Python 3.