### PR TITLE
Fix truthiness check in config.py

### DIFF
--- a/olclient/config.py
+++ b/olclient/config.py
@@ -130,5 +130,5 @@ class Config(object):
         access = config['s3'].pop('access')
         secret = config['s3'].pop('secret')
         config['s3'] = Credentials(
-            access, secret) if all((access, secret)) else None
+            access, secret) if access and secret else None
         return config

--- a/olclient/config.py
+++ b/olclient/config.py
@@ -130,5 +130,5 @@ class Config(object):
         access = config['s3'].pop('access')
         secret = config['s3'].pop('secret')
         config['s3'] = Credentials(
-            access, secret) if (access, secret) else None
+            access, secret) if all((access, secret)) else None
         return config


### PR DESCRIPTION
This PR closes #168

## Description:

On line 132 of `config.py` the following check is performed:

```config['s3'] = Credentials(access, secret) if (access, secret) else None```

I'm assuming the goal is here to check if `access` and `secret` are set and then login with these credentials. The problem though is that, this statement actually only checks if the tuple contains any values, not if they are both truthy.
My fix is to surround the tuple with a call to `all()`. One could also consider using `any()` (or just `if access`), but I don't think there would be a use case where the secret is empty.