### PR TITLE
setup.py: Drop support for Python 3.4 & 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ openlibrary-client
 
 ![Travis CI build status](https://travis-ci.org/internetarchive/openlibrary-client.svg?branch=master)
 
-A reference client library for the Open Library API. Tested with Python 2.7, 3.5, 3.6.
+A reference client library for the Open Library API. Tested with Python 2.7, 3.7, 3.8.
 
 - [Installation](#installation)
 - [Configuration](#configuration)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ def read(*parts):
     intentionally *not* adding an encoding option to open, See:
        https://github.com/pypa/virtualenv/issues/201#issuecomment-3145690
     """
-    return codecs.open(os.path.join(here, *parts), 'r').read()
+    with codecs.open(os.path.join(here, *parts), 'r') as in_file:
+        return in_file.read()
 
 
 def find_version(*file_paths):
@@ -45,7 +46,7 @@ def requirements():
 setup(
     name='openlibrary-client',
     version=find_version("olclient", "__init__.py"),
-    description=u'A python client for Open Library',
+    description=u'A Python client for Open Library',
     long_description=read('README.md'),
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4"
+        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8"
     ],
     author='Internet Archive',
     author_email='mek@archive.org',


### PR DESCRIPTION
https://devguide.python.org/#status-of-python-branches Python 3.6 thru 3.9 are supported.
https://devguide.python.org/devcycle/#end-of-life-branches Python < 3.6 is are no longer supported.