### PR TITLE
Remove Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: bionic
 
 language: python
 python:
-  - "2.7"
   - "3.7"
   - "3.8"
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ openlibrary-client
 
 ![Travis CI build status](https://travis-ci.org/internetarchive/openlibrary-client.svg?branch=master)
 
-A reference client library for the Open Library API. Tested with Python 2.7, 3.5, 3.6.
+A reference client library for the Open Library API. Tested with Python 3.7, 3.8.
 
 - [Installation](#installation)
 - [Configuration](#configuration)
@@ -27,14 +27,12 @@ $ sudo dnf install yaz
 You'll also need python dev tools:
 
 ```
-$ sudo apt install python-dev   # for python 2
-$ sudo apt install python3-dev  # for python 3
+$ sudo apt install python3-dev
 ```
 
 For Fedora/RHEL, use:
 ```
-$ sudo dnf install python2-devel  # for python2.x installs
-$ sudo dnf install python3-devel  # for python3.x installs
+$ sudo dnf install python3-devel
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -54,10 +54,9 @@ setup(
         "Topic :: Software Development :: Build Tools",
         "Topic :: Software Development :: Libraries",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4"
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8"
     ],
     author='Internet Archive',
     author_email='mek@archive.org',
@@ -68,9 +67,6 @@ setup(
         ],
     entry_points={
         'console_scripts': ['ol=olclient.cli:main'],
-    },
-    extras_require={
-        ':python_version=="2.7"': ['argparse']
     },
     platforms='any',
     license='LICENSE',


### PR DESCRIPTION
Closes #193

There might still be some residual code with py2/3 code, but no longer test on/say that we support py 2
Pulled the minimal set of changes from #180

Note:
- This is blocking #178