### PR TITLE
Follow next link while populating editions for work

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -2,7 +2,7 @@
 
 
 import json
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 
 import jsonschema
 import logging
@@ -198,12 +198,12 @@ class OpenLibrary:
                 """
                 url = f'{self.OL.base_url}/works/{self.olid}/editions.json'
                 try:
-                    r_json: Dict = self.OL.session.get(url).json()
-                    editions: List = r_json.get('entries', [])
+                    r_json: Dict[Any, Any] = self.OL.session.get(url).json()
+                    editions: List[Any] = r_json.get('entries', [])
                     while True:
                         next_page_link: Optional[str] = r_json.get('links', {}).get('next')
                         if next_page_link is not None:
-                            r_json: Dict = self.OL.session.get(f'{self.OL.base_url}{next_page_link}').json()
+                            r_json: Dict[Any, Any] = self.OL.session.get(self.OL.base_url + next_page_link).json()
                             editions.extend(r_json.get('entries', []))
                         else:
                             break

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -2,6 +2,8 @@
 
 
 import json
+from typing import List, Dict, Optional
+
 import jsonschema
 import logging
 import os
@@ -196,8 +198,15 @@ class OpenLibrary:
                 """
                 url = f'{self.OL.base_url}/works/{self.olid}/editions.json'
                 try:
-                    r = self.OL.session.get(url)
-                    editions = r.json().get('entries', [])
+                    r_json: Dict = self.OL.session.get(url).json()
+                    editions: List = r_json.get('entries', [])
+                    while True:
+                        next_page_link: Optional[str] = r_json.get('links', {}).get('next')
+                        if next_page_link is not None:
+                            r_json: Dict = self.OL.session.get(f'{self.OL.base_url}{next_page_link}').json()
+                            editions.extend(r_json.get('entries', []))
+                        else:
+                            break
                 except Exception as e:
                     return []
 


### PR DESCRIPTION
This PR closes https://github.com/internetarchive/openlibrary-client/issues/219

## Description:
Follows next link if present while populating editions

```python
import olclient

open_library = olclient.OpenLibrary()
work = open_library.Work.get(u'OL495934W')
editions = work.editions
print(len(editions)) # now returns 184 instead of 50
```