### PR TITLE
Send success output of cli to STDOUT

### DIFF
--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -91,7 +91,7 @@ def main() -> None:
             return None
 
         config_tool.update(config)
-        sys.stdout.write("Successfully configured")
+        print("Successfully configured")
         return None
 
     # prompt first time users to configure their OpenLibrary credentials
@@ -107,37 +107,29 @@ def main() -> None:
             raise
 
     if args.get_olid:
-        sys.stdout.write(ol.Edition.get_olid_by_isbn(args.isbn))
-        return None
+        print(ol.Edition.get_olid_by_isbn(args.isbn))
     elif args.get_book:
         if args.olid:
-            sys.stdout.write(jsonpickle.encode(ol.Edition.get(olid=args.olid)))
-            return None
+            print(jsonpickle.encode(ol.Edition.get(olid=args.olid)))
         elif args.isbn:
-            sys.stdout.write(jsonpickle.encode(ol.Edition.get(isbn=args.isbn)))
-            return None
+            print(jsonpickle.encode(ol.Edition.get(isbn=args.isbn)))
     elif args.get_work:
         if args.olid:
-            sys.stdout.write(jsonpickle.encode(ol.Work.get(args.olid)))
-            return None
+            print(jsonpickle.encode(ol.Work.get(args.olid)))
         elif args.title:
-            sys.stdout.write(jsonpickle.encode(ol.Work.search(args.title)))
-            return None
+            print(jsonpickle.encode(ol.Work.search(args.title)))
     elif args.get_author_works:
         if args.olid:
-            sys.stdout.write(jsonpickle.encode(ol.Author.get(args.olid).works()))
-            return None
+            print(jsonpickle.encode(ol.Author.get(args.olid).works()))
         elif args.author_name:
-            sys.stdout.write(jsonpickle.encode(ol.Author.get(ol.Author.get_olid_by_name(args.author_name)).works()))
-            return None
+            print(jsonpickle.encode(ol.Author.get(ol.Author.get_olid_by_name(args.author_name)).works()))
     elif args.create:
         data = json.loads(args.create)
         title = data.pop('title')
         author = common.Author(data.pop('author'))
         book = common.Book(title, authors=[author], **data)
         edition = ol.Work.create(book)
-        sys.stdout.write(edition.olid)
-        return None
+        print(edition.olid)
     else:
         return parser.print_help()
 

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -66,7 +66,7 @@ def argparser():
     return parser
 
 
-def main():
+def main() -> None:
     parser = argparser()
     args = parser.parse_args()
 
@@ -85,10 +85,12 @@ def main():
             ol = OpenLibrary(credentials=Credentials(**config['s3']),
                              base_url=args.baseurl)
         except:
-            return "Incorrect credentials, not updating config."
+            sys.stderr.write("Incorrect credentials, not updating config.")
+            return None
 
         config_tool.update(config)
-        return "Successfully configured "
+        sys.stdout.write("Successfully configured")
+        return None
 
     # prompt first time users to configure their OpenLibrary credentials
     try:
@@ -104,28 +106,28 @@ def main():
 
     if args.get_olid:
         sys.stdout.write(ol.Edition.get_olid_by_isbn(args.isbn))
-        return
+        return None
     elif args.get_book:
         if args.olid:
             sys.stdout.write(jsonpickle.encode(ol.Edition.get(olid=args.olid)))
-            return
+            return None
         elif args.isbn:
             sys.stdout.write(jsonpickle.encode(ol.Edition.get(isbn=args.isbn)))
-            return
+            return None
     elif args.get_work:
         if args.olid:
             sys.stdout.write(jsonpickle.encode(ol.Work.get(args.olid)))
-            return
+            return None
         elif args.title:
             sys.stdout.write(jsonpickle.encode(ol.Work.search(args.title)))
-            return
+            return None
     elif args.get_author_works:
         if args.olid:
             sys.stdout.write(jsonpickle.encode(ol.Author.get(args.olid).works()))
-            return
+            return None
         elif args.author_name:
             sys.stdout.write(jsonpickle.encode(ol.Author.get(ol.Author.get_olid_by_name(args.author_name)).works()))
-            return
+            return None
     elif args.create:
         data = json.loads(args.create)
         title = data.pop('title')
@@ -133,7 +135,7 @@ def main():
         book = common.Book(title, authors=[author], **data)
         edition = ol.Work.create(book)
         sys.stdout.write(edition.olid)
-        return
+        return None
     else:
         return parser.print_help()
 

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -88,11 +88,11 @@ def main() -> None:
             )
         except:
             sys.stderr.write("Incorrect credentials, not updating config.")
-            return None
+            return
 
         config_tool.update(config)
         print("Successfully configured")
-        return None
+        return
 
     # prompt first time users to configure their OpenLibrary credentials
     try:
@@ -131,7 +131,7 @@ def main() -> None:
         edition = ol.Work.create(book)
         print(edition.olid)
     else:
-        return parser.print_help()
+        parser.print_help()
 
 
 if __name__ == "__main__":

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -82,8 +82,10 @@ def main() -> None:
         config['s3'] = ia.config.get_config()['s3']
 
         try:
-            ol = OpenLibrary(credentials=Credentials(**config['s3']),
-                             base_url=args.baseurl)
+            ol = OpenLibrary(
+                credentials=Credentials(**config['s3']),
+                base_url=args.baseurl
+            )
         except:
             sys.stderr.write("Incorrect credentials, not updating config.")
             return None

--- a/olclient/cli.py
+++ b/olclient/cli.py
@@ -103,29 +103,37 @@ def main():
             raise
 
     if args.get_olid:
-        return ol.Edition.get_olid_by_isbn(args.isbn)
+        sys.stdout.write(ol.Edition.get_olid_by_isbn(args.isbn))
+        return
     elif args.get_book:
         if args.olid:
-            return jsonpickle.encode(ol.Edition.get(olid=args.olid))
+            sys.stdout.write(jsonpickle.encode(ol.Edition.get(olid=args.olid)))
+            return
         elif args.isbn:
-            return jsonpickle.encode(ol.Edition.get(isbn=args.isbn))
+            sys.stdout.write(jsonpickle.encode(ol.Edition.get(isbn=args.isbn)))
+            return
     elif args.get_work:
         if args.olid:
-            return jsonpickle.encode(ol.Work.get(args.olid))
+            sys.stdout.write(jsonpickle.encode(ol.Work.get(args.olid)))
+            return
         elif args.title:
-            return jsonpickle.encode(ol.Work.search(args.title))
+            sys.stdout.write(jsonpickle.encode(ol.Work.search(args.title)))
+            return
     elif args.get_author_works:
         if args.olid:
-            return jsonpickle.encode(ol.Author.get(args.olid).works())
+            sys.stdout.write(jsonpickle.encode(ol.Author.get(args.olid).works()))
+            return
         elif args.author_name:
-            return jsonpickle.encode(ol.Author.get(ol.Author.get_olid_by_name(args.author_name)).works())
+            sys.stdout.write(jsonpickle.encode(ol.Author.get(ol.Author.get_olid_by_name(args.author_name)).works()))
+            return
     elif args.create:
         data = json.loads(args.create)
         title = data.pop('title')
         author = common.Author(data.pop('author'))
         book = common.Book(title, authors=[author], **data)
         edition = ol.Work.create(book)
-        return edition.olid
+        sys.stdout.write(edition.olid)
+        return
     else:
         return parser.print_help()
 


### PR DESCRIPTION
This PR closes https://github.com/internetarchive/openlibrary-client/issues/215

## Description:

We should be writing to stdout if the cli tool succedes.
`argparse`'s `print_help` (which we use in `cli.py`) uses `sys.stdout.write` too

https://github.com/python/cpython/blob/d35eef3b904b62e9c775bf3764ab0a0611f5a860/Lib/argparse.py#L2545-L2548