### PR TITLE
Fix limit parsing in AbstractBotJob

### DIFF
--- a/examples/scripts/making_a_bot.py
+++ b/examples/scripts/making_a_bot.py
@@ -28,7 +28,11 @@ class TrimTitleJob(AbstractBotJob):
 
         comment = 'trim whitespace'
         with gzip.open(self.args.file, 'rb') as fin:
-            for row in fin:
+            for line_number, row in enumerate(fin):
+
+                if line_number >= self.limit:
+                    return
+
                 # extract info from the dump file and check it
                 row, json_data = self.process_row(row)
                 if json_data['type']['key'] != '/type/edition':
@@ -53,7 +57,7 @@ class TrimTitleJob(AbstractBotJob):
                 self.save(lambda: edition.save(comment=comment))
 
 
-if '__name__' == __name__:
+if __name__ == '__main__':
     job = TrimTitleJob()
 
     try:

--- a/examples/scripts/making_a_bot.py
+++ b/examples/scripts/making_a_bot.py
@@ -28,10 +28,7 @@ class TrimTitleJob(AbstractBotJob):
 
         comment = 'trim whitespace'
         with gzip.open(self.args.file, 'rb') as fin:
-            for line_number, row in enumerate(fin):
-
-                if line_number >= self.limit:
-                    return
+            for row in fin:
 
                 # extract info from the dump file and check it
                 row, json_data = self.process_row(row)
@@ -55,9 +52,7 @@ class TrimTitleJob(AbstractBotJob):
                     '\t'.join([olid, old_title, edition.title])
                 )  # don't forget to log modifications!
 
-                if self.dry_run is False:
-                    # save only if dry_run is false!
-                    self.save(lambda: edition.save(comment=comment))
+                self.save(lambda: edition.save(comment=comment))
 
 
 if __name__ == '__main__':

--- a/examples/scripts/making_a_bot.py
+++ b/examples/scripts/making_a_bot.py
@@ -29,7 +29,6 @@ class TrimTitleJob(AbstractBotJob):
         comment = 'trim whitespace'
         with gzip.open(self.args.file, 'rb') as fin:
             for row in fin:
-
                 # extract info from the dump file and check it
                 row, json_data = self.process_row(row)
                 if json_data['type']['key'] != '/type/edition':
@@ -48,10 +47,8 @@ class TrimTitleJob(AbstractBotJob):
                 # this edition needs editing, so fix it
                 old_title = copy.deepcopy(edition.title)
                 edition.title = edition.title.strip()
-                self.logger.info(
-                    '\t'.join([olid, old_title, edition.title])
-                )  # don't forget to log modifications!
-
+                # don't forget to log modifications!
+                self.logger.info('\t'.join([olid, old_title, edition.title]))
                 self.save(lambda: edition.save(comment=comment))
 
 

--- a/examples/scripts/making_a_bot.py
+++ b/examples/scripts/making_a_bot.py
@@ -54,7 +54,10 @@ class TrimTitleJob(AbstractBotJob):
                 self.logger.info(
                     '\t'.join([olid, old_title, edition.title])
                 )  # don't forget to log modifications!
-                self.save(lambda: edition.save(comment=comment))
+
+                if self.dry_run is False:
+                    # save only if dry_run is false!
+                    self.save(lambda: edition.save(comment=comment))
 
 
 if __name__ == '__main__':

--- a/olclient/bots.py
+++ b/olclient/bots.py
@@ -32,7 +32,8 @@ class AbstractBotJob:
             help='Path to file containing input data',
         )
         self.parser.add_argument(
-            '-l, --limit',
+            '-l',
+            '--limit',
             type=int,
             default=1,
             help='Limit number of edits performed on external data.'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ mypy
 flake8==3.9.1
 pytest==6.2.3
 pytest-socket
+types-requests==2.25.0


### PR DESCRIPTION
This PR closes #237

## Description:
Limit parsing was not functional because the definition of the flag was incorrect. This fixes it.