### PR TITLE
Fix dry run parsing in AbstractBotJob

### DIFF
--- a/olclient/bots.py
+++ b/olclient/bots.py
@@ -42,11 +42,11 @@ class AbstractBotJob:
             '-d',
             '--dry-run',
             type=self._str2bool,
-            default=True,
             help='Execute the script without performing edits on external data.',
         )
         self.args = self.parser.parse_args()
-        self.dry_run = getattr(self.args, 'dry_run', dry_run)
+        dry_run_from_args = getattr(self.args, 'dry_run', None)
+        self.dry_run = dry_run_from_args if dry_run_from_args is not None else dry_run
         self.limit = getattr(self.args, 'limit', None) or limit
         self.changed = 0
 

--- a/olclient/bots.py
+++ b/olclient/bots.py
@@ -46,7 +46,7 @@ class AbstractBotJob:
             help='Execute the script without performing edits on external data.',
         )
         self.args = self.parser.parse_args()
-        self.dry_run = getattr(self.args, 'dry-run', None) or dry_run
+        self.dry_run = getattr(self.args, 'dry_run', dry_run)
         self.limit = getattr(self.args, 'limit', None) or limit
         self.changed = 0
 


### PR DESCRIPTION
## Description:

argparse converts `-` into `_` after parsing the arguments. Quoting from https://docs.python.org/dev/library/argparse.html#dest

```
Any internal - characters will be converted to _ characters to make sure the string is a valid attribute name.
```

The parser was retrieving `dry-run` from `self.args` instead of `dry_run`. Which was causing the parsing issue for bots.

`dry_run` could be sourced from three different places
- user cli input
- class default argument
- argparse default

`dry_run` is an argument passed in to the  `AbstractBotJob`'s `__init__` fn with a default value of true. And the parser logic was `self.dry_run = getattr(self.args, 'dry_run', None) or dry_run`. So if dry run was passed as false from the cli args, the line would be `False or True`, which would result in true. Thereby over riding whatever was set by the cli. I don't think this is the expected behaviour. Also there is a default set at the parser level (to true). The way it behaves is that, if the class was instantiated programmatically, this would still set `self.args['dry_run']` to true. 

Currently the revised code will check for the value in args, if it does not exist will fallback to the class init argument (which defaults to true).

Let me know if I missed anything.