### PR TITLE
Added delete fn on work

### DIFF
--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -6,6 +6,7 @@ import re
 from typing import List, Dict, Optional, Any
 
 import backoff
+from requests import Response
 
 from olclient.common import Entity, Book
 from olclient.helper_classes.results import Results
@@ -141,8 +142,8 @@ def get_work_helper_class(ol_context):
         def _delete_editions(self, comment: str) -> None:
             edition_olids: List[str] = [edition_data.olid for edition_data in self.editions]
             if len(edition_olids) > 0:
-                editions_cleanup_response = self.OL.delete_many(edition_olids, comment)
-                if len(self.editions) > 0:
+                editions_cleanup_response: Response = self.OL.delete_many(edition_olids, comment)
+                if editions_cleanup_response.ok is False:
                     raise Exception(f'Could not delete all editions of work {self.olid}. '
                                     f'response: {editions_cleanup_response}')
 

--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -143,7 +143,7 @@ def get_work_helper_class(ol_context):
             edition_olids: List[str] = [edition_data.olid for edition_data in self.editions]
             edition_count = len(edition_olids)
             should_delete = confirm is False or get_approval_from_cli(
-                f'Delete https://openlibrary.org/works/{self.olid} and its {edition_count} editions?'
+                f'Delete https://openlibrary.org/works/{self.olid} and its {edition_count} editions? (y/n)'
             )
             if should_delete is False:
                 return

--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -139,7 +139,7 @@ def get_work_helper_class(ol_context):
             data['subjects'] = list(set(data['subjects']) - set(subjects))
             return self.OL.session.put(url, json.dumps(data))
 
-        def delete(self, comment: str, confirm: bool = True):
+        def delete(self, comment: str, confirm: bool = True) -> Optional[Response]:
             edition_olids: List[str] = [edition_data.olid for edition_data in self.editions]
             edition_count = len(edition_olids)
             should_delete = confirm is False or get_approval_from_cli(

--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -138,13 +138,17 @@ def get_work_helper_class(ol_context):
             data['subjects'] = list(set(data['subjects']) - set(subjects))
             return self.OL.session.put(url, json.dumps(data))
 
-        def delete(self, comment: str, editions: bool = False):
-            if editions is True:
-                all_editions_of_work: List = self.editions
-                edition_olids: List[str] = [edition_data.olid for edition_data in all_editions_of_work]
+        def _delete_editions(self, comment: str) -> None:
+            edition_olids: List[str] = [edition_data.olid for edition_data in self.editions]
+            if len(edition_olids) > 0:
                 editions_cleanup_response = self.OL.delete_many(edition_olids, comment)
                 if len(self.editions) > 0:
-                    raise Exception(f'Could not delete all editions of work {self.olid}. response: {editions_cleanup_response}')
+                    raise Exception(f'Could not delete all editions of work {self.olid}. '
+                                    f'response: {editions_cleanup_response}')
+
+        def delete(self, comment: str, editions: bool = False):
+            if editions is True:
+                self._delete_editions(comment)
             return self.OL.delete(self.olid)
 
         def save(self, comment):

--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -139,12 +139,6 @@ def get_work_helper_class(ol_context):
             data['subjects'] = list(set(data['subjects']) - set(subjects))
             return self.OL.session.put(url, json.dumps(data))
 
-        def _delete_editions(self, edition_olids: List[str], comment: str) -> None:
-            editions_cleanup_response: Response = self.OL.delete_many(edition_olids, comment)
-            if editions_cleanup_response.ok is False:
-                raise Exception(f'Could not delete all editions of work {self.olid}. '
-                                f'response: {editions_cleanup_response}')
-
         def delete(self, comment: str, confirm: bool = True):
             edition_olids: List[str] = [edition_data.olid for edition_data in self.editions]
             edition_count = len(edition_olids)

--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -19,7 +19,7 @@ def get_work_helper_class(ol_context):
 
         OL = ol_context
 
-        def __init__(self, olid, identifiers=None, **kwargs):
+        def __init__(self, olid: str, identifiers=None, **kwargs):
             super().__init__(identifiers)
             self.olid = olid
             self._editions = []
@@ -137,6 +137,15 @@ def get_work_helper_class(ol_context):
             data['_comment'] = comment or ('rm subjects: %s' % ', '.join(subjects))
             data['subjects'] = list(set(data['subjects']) - set(subjects))
             return self.OL.session.put(url, json.dumps(data))
+
+        def delete(self, comment: str, editions: bool = False):
+            if editions is True:
+                all_editions_of_work: List = self.editions
+                edition_olids: List[str] = [edition_data.olid for edition_data in all_editions_of_work]
+                editions_cleanup_response = self.OL.delete_many(edition_olids, comment)
+                if len(self.editions) > 0:
+                    raise Exception(f'Could not delete all editions of work {self.olid}. response: {editions_cleanup_response}')
+            return self.OL.delete(self.olid)
 
         def save(self, comment):
             """Saves this work back to Open Library using the JSON API."""

--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -154,9 +154,7 @@ def get_work_helper_class(ol_context):
             if should_delete is False:
                 return
 
-            if edition_count > 0:
-                self._delete_editions(edition_olids, comment)
-            return self.OL.delete(self.olid)
+            return self.OL.delete_many([self.olid, *edition_olids], comment)
 
         def save(self, comment):
             """Saves this work back to Open Library using the JSON API."""

--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -146,7 +146,7 @@ def get_work_helper_class(ol_context):
                 f'Delete https://openlibrary.org/works/{self.olid} and its {edition_count} editions? (y/n)'
             )
             if should_delete is False:
-                return
+                return None
 
             return self.OL.delete_many([self.olid, *edition_olids], comment)
 

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -12,6 +12,7 @@ from urllib.parse import urlencode
 
 import backoff
 import requests
+from requests import Response
 
 from . import common
 from .config import Config
@@ -117,7 +118,7 @@ class OpenLibrary:
         url = self._generate_url_from_olid(olid)
         return self.session.put(url, data=data)
 
-    def save_many(self, docs, comment):
+    def save_many(self, docs, comment) -> Response:
         """
         Uses the Open Library save_many API endpoint to
         write any number or combination of documents (Edition, Work, or Author)
@@ -133,7 +134,7 @@ class OpenLibrary:
             '%s/api/save_many' % self.base_url, json.dumps(doc_json), headers=headers
         )
 
-    def delete_many(self, ol_ids: List[str], comment: str):
+    def delete_many(self, ol_ids: List[str], comment: str) -> Response:
         return self.save_many(
             [self.Delete(ol_id) for ol_id in ol_ids],
             comment=comment

--- a/olclient/utils.py
+++ b/olclient/utils.py
@@ -119,4 +119,4 @@ def extract_olid_from_url(url, url_type):
 
 def get_approval_from_cli(message: str) -> bool:
     approval_str: str = input(message)
-    return approval_str.lower() == 'y'
+    return input(message).strip().lower() in ('y', 'yes')

--- a/olclient/utils.py
+++ b/olclient/utils.py
@@ -118,5 +118,4 @@ def extract_olid_from_url(url, url_type):
 
 
 def get_approval_from_cli(message: str) -> bool:
-    approval_str: str = input(message)
     return input(message).strip().lower() in ('y', 'yes')

--- a/olclient/utils.py
+++ b/olclient/utils.py
@@ -115,3 +115,8 @@ def extract_olid_from_url(url, url_type):
         return re.search(ol_url_pattern, url).group(1)
     except AttributeError:
         return None  # No match
+
+
+def get_approval_from_cli(message: str) -> bool:
+    approval_str: str = input(message)
+    return approval_str.lower() == 'y'


### PR DESCRIPTION
This PR closes #234

## Description:
Deleting work along with its editions is something done very often in bots, this helps by making sure the work is deleted if and only if the editions are deleted as well