### PR TITLE
Added recently added folders to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,5 @@ include olclient/schemata/author.schema.json
 include olclient/schemata/edition.schema.json
 include olclient/schemata/work.schema.json
 include olclient/schemata/shared_definitions.json
+include olclient/entity_helpers/*
+include olclient/helper_classes/*


### PR DESCRIPTION
Before updating MANIFEST.in

```
(venv) (base) ➜  openlibrary-client git:(master) pip install .
# install output...
(venv) (base) ➜  openlibrary-client git:(master) cd venv/lib/python3.9/site-packages/olclient
(venv) (base) ➜  olclient git:(master) ls
__init__.py  __pycache__  bots.py  cli.py  common.py  config.py  openlibrary.py  schemata  utils.py
```

`entity_helpers` and `helper_classess` are not currently packaged at this point.

```
(venv) (base) ➜  openlibrary-client git:(fix/add_folders_manifest_json) pip install . 
# install output..
(venv) (base) ➜  openlibrary-client git:(fix/add_folders_manifest_json) cd venv/lib/python3.9/site-packages/olclient
(venv) (base) ➜  olclient git:(fix/add_folders_manifest_json) ls
__init__.py  __pycache__  bots.py  cli.py  common.py  config.py  entity_helpers  helper_classes  openlibrary.py  schemata  utils.py
```
After adding these folders to MANIFEST.in, they are explicitly asked to be packaged as a part of the dist. [documentation](https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist)