### PR TITLE
AbstactBotJob: use write changes instead of dry_run + store_true

### DIFF
--- a/olclient/bots.py
+++ b/olclient/bots.py
@@ -46,7 +46,7 @@ class AbstractBotJob:
             help='Execute the script and write all changes to external data.',
         )
         self.args = self.parser.parse_args()
-        self.write_changes = self.args.write_changes
+        self.write_changes = write_changes or self.args.write_changes 
         self.limit = getattr(self.args, 'limit', None) or limit
         self.changed = 0
 
@@ -73,7 +73,8 @@ class AbstractBotJob:
             self.logger.info('write_changes is TRUE. Permanent modifications may be made.')
         else:
             self.logger.info('write_changes is FALSE. No external modifications will be made.')
-
+    def dry_run_declaration(self):
+        self.write_changes_declaration()
     @staticmethod
     def process_row(row, delimiter='\t') -> Tuple[list, dict]:
         """

--- a/olclient/bots.py
+++ b/olclient/bots.py
@@ -42,12 +42,11 @@ class AbstractBotJob:
         self.parser.add_argument(
             '-w',
             '--write-changes',
-            type=self._str2bool,
-            default=False,
+            action="store_true",
             help='Execute the script and write all changes to external data.',
         )
         self.args = self.parser.parse_args()
-        self.write_changes = write_changes or getattr(self.args, 'write-changes', False)
+        self.write_changes = self.args.write_changes
         self.limit = getattr(self.args, 'limit', None) or limit
         self.changed = 0
 

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -24,7 +24,7 @@ class TestBots(unittest.TestCase):
         bot = AbstractBotJob()
         assert bot.changed == 0
         assert bot.limit == 1
-        assert bot.dry_run is True
+        assert bot.write_changes is False
         assert bot.logger.handlers
         assert getattr(bot, 'console_handler', None) is not None
         assert isinstance(bot.ol, OpenLibrary)
@@ -45,20 +45,20 @@ class TestBots(unittest.TestCase):
             ArgumentTypeError, bot._str2bool, 'this is a non-boolean string'
         )
 
-    def test_dry_run_declaration_when_dry_run_is_true(self, mock_login):
-        bot = AbstractBotJob(dry_run=True)
+    def test_write_changes_declaration_when_write_changes_is_true(self, mock_login):
+        bot = AbstractBotJob(write_changes=True)
         bot.logger.info = Mock()
-        bot.dry_run_declaration()
+        bot.write_changes_declaration()
         bot.logger.info.assert_called_with(
-            'dry-run is TRUE. No external modifications will be made.'
+            'write_changes is TRUE. Permanent modifications may be made.'
         )  # TODO
 
-    def test_dry_run_declaration_when_dry_run_is_false(self, mock_login):
-        bot = AbstractBotJob(dry_run=False)
+    def test_write_changes_declaration_when_write_changes_is_false(self, mock_login):
+        bot = AbstractBotJob(write_changes=False)
         bot.logger.info = Mock()
-        bot.dry_run_declaration()
+        bot.write_changes_declaration()
         bot.logger.info.assert_called_with(
-            'dry-run is FALSE. Permanent modifications can be made.'
+            'write_changes is FALSE. No external modifications will be made.'
         )  # TODO
 
     def test_process_row_with_bytecode(self, mock_login):
@@ -105,7 +105,7 @@ class TestBots(unittest.TestCase):
     @patch('olclient.bots.sys.exit')
     def test_save_exits_when_limit_reached(self, mock_login, mock_sys_exit):
         save_fn = Mock()
-        bot = AbstractBotJob(dry_run=True, limit=10)
+        bot = AbstractBotJob(write_changes=False, limit=10)
         bot.logger.info = Mock()
         for i in range(
             bot.limit
@@ -119,9 +119,9 @@ class TestBots(unittest.TestCase):
         assert bot.logger.info.call_count == bot.limit + 1
 
     @patch('olclient.bots.sys.exit')
-    def test_save_when_dry_run_is_false(self, mock_login, mock_sys_exit):
+    def test_save_when_write_changes_is_true(self, mock_login, mock_sys_exit):
         save_fn = Mock()
-        bot = AbstractBotJob(dry_run=False)
+        bot = AbstractBotJob(write_changes=True)
         bot.logger.info = Mock()
         old_changed = copy.deepcopy(bot.changed)
         bot.save(save_fn)
@@ -132,9 +132,9 @@ class TestBots(unittest.TestCase):
         assert not bot.changed > bot.limit
 
     @patch('olclient.bots.sys.exit')
-    def test_save_when_dry_run_is_true(self, mock_login, mock_sys_exit):
+    def test_save_when_write_changes_is_false(self, mock_login, mock_sys_exit):
         save_fn = Mock()
-        bot = AbstractBotJob(dry_run=True)
+        bot = AbstractBotJob(write_changes=False)
         bot.logger.info = Mock()
         old_changed = copy.deepcopy(bot.changed)
         bot.save(save_fn)


### PR DESCRIPTION
This PR closes #241 

## Description:
Basically #241 with store_true + backwards compatability . Tested locally for the basic case