### PR TITLE
Add identifiers to import schema

### DIFF
--- a/olclient/schemata/import.schema.json
+++ b/olclient/schemata/import.schema.json
@@ -98,7 +98,13 @@
       "type": "object",
       "patternProperties": {
         "^\\w+": { "$ref": "shared_definitions.json#/string_array" }
-      }
+      },
+      "description": "Unique identifiers used by external sites to identify a book. Useful for linking to other sites.",
+      "examples": [
+        "standard_ebooks",
+        "project_gutenberg",
+        "wikisource"
+      ]
     }
   },
   "definitions": {

--- a/olclient/schemata/import.schema.json
+++ b/olclient/schemata/import.schema.json
@@ -99,7 +99,7 @@
       "patternProperties": {
         "^\\w+": { "$ref": "shared_definitions.json#/string_array" }
       },
-      "description": "Unique identifiers used by external sites to identify a book. Useful for linking to other sites.",
+      "description": "Unique identifiers used by external sites to identify a book. Used by Open Library to link offsite.",
       "examples": [
         "standard_ebooks",
         "project_gutenberg",

--- a/olclient/schemata/import.schema.json
+++ b/olclient/schemata/import.schema.json
@@ -93,6 +93,12 @@
         "12 ounces",
         "1 pounds"
       ]
+    },
+    "identifiers": {
+      "type": "object",
+      "patternProperties": {
+        "^\\w+": { "$ref": "shared_definitions.json#/string_array" }
+      }
     }
   },
   "definitions": {

--- a/olclient/schemata/import.schema.json
+++ b/olclient/schemata/import.schema.json
@@ -101,9 +101,12 @@
       },
       "description": "Unique identifiers used by external sites to identify a book. Used by Open Library to link offsite.",
       "examples": [
-        "standard_ebooks",
-        "project_gutenberg",
-        "wikisource"
+        {
+            "standard_ebooks": ["leo-tolstoy/what-is-art/aylmer-maude"]
+        },
+        {
+            "project_gutenberg": ["64317"]
+        }
       ]
     }
   },


### PR DESCRIPTION
## Description:
Adds optional `identifiers` field to our import object schema.  `identifiers` is an object that maps lists of stings to a string key.