### PR TITLE
Add cover URL to import schema

### DIFF
--- a/olclient/schemata/import.schema.json
+++ b/olclient/schemata/import.schema.json
@@ -108,6 +108,13 @@
             "project_gutenberg": ["64317"]
         }
       ]
+    },
+    "cover": {
+      "type": "string",
+      "description": "URL for an edition's cover",
+      "examples": [
+        "https://www.example.com/images/8.jpeg"
+      ]
     }
   },
   "definitions": {


### PR DESCRIPTION
## Description:
This adds `cover` property to our import schemata.


This is in support of https://github.com/internetarchive/openlibrary/issues/5993