### PR TITLE
Convert to Python f-strings for speed.

### DIFF
--- a/olclient/bots.py
+++ b/olclient/bots.py
@@ -119,7 +119,7 @@ class AbstractBotJob:
         :param job_name: The name that will appear on the log files
         :returns: a tuple of the logger instance and the console handler instance
         """
-        logger = logging.getLogger("jobs.%s" % job_name)
+        logger = logging.getLogger(f"jobs.{job_name}")
         logger.setLevel(logging.DEBUG)
         log_formatter = logging.Formatter(
             '%(name)s;%(levelname)-8s;%(asctime)s %(message)s'

--- a/olclient/bots.py
+++ b/olclient/bots.py
@@ -6,16 +6,15 @@ Classes and methods for bulk edits that match the following pattern:
 4. Repeat 1-3 for all records that meet condition X
 """
 
-
 import argparse
-import datetime
 import json
 import logging
 import sys
-
-from typing import Tuple
-from olclient.openlibrary import OpenLibrary
+from datetime import datetime
 from os import makedirs, path
+from typing import Tuple
+
+from olclient.openlibrary import OpenLibrary
 
 
 class AbstractBotJob:
@@ -131,8 +130,7 @@ class AbstractBotJob:
         here = path.dirname(path.abspath(__name__))
         log_dir = path.join(here, 'logs', 'jobs', job_name)
         makedirs(log_dir, exist_ok=True)
-        log_file_datetime = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        log_file = path.join(log_dir, f'{job_name}_{log_file_datetime}.log')
+        log_file = path.join(log_dir, f'{job_name}_{datetime.now():%Y%m%d_%H%M%S}.log')
         file_handler = logging.FileHandler(log_file)
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(log_formatter)

--- a/olclient/common.py
+++ b/olclient/common.py
@@ -56,7 +56,7 @@ class Entity:
         return self.identifiers
 
     def __repr__(self):
-        return '<{} {}>'.format(str(self.__class__)[1:-1], self.__dict__)
+        return f'<{str(self.__class__)[1:-1]} {self.__dict__}>'
 
 
 class Author(Entity):
@@ -78,7 +78,7 @@ class Author(Entity):
             setattr(self, kwarg, kwargs[kwarg])
 
     def __repr__(self):
-        return '<{} {}>'.format(str(self.__class__)[1:-1], self.__dict__)
+        return f'<{str(self.__class__)[1:-1]} {self.__dict__}>'
 
     @staticmethod
     def _validate_name(name):
@@ -133,7 +133,7 @@ class Book(Entity):
             setattr(self, kwarg, kwargs[kwarg])
 
     def __repr__(self):
-        return '<{} {}>'.format(str(self.__class__)[1:-1], self.__dict__)
+        return f'<{str(self.__class__)[1:-1]} {self.__dict__}>'
 
     @property
     def canonical_title(self):
@@ -184,6 +184,6 @@ class Book(Entity):
                 publish_date=ed.get('year', None),
             )
             for isbn in isbns:
-                book.add_id('isbn_%s' % len(isbn), isbn)
+                book.add_id(f'isbn_{len(isbn)}', isbn)
             books.append(book)
         return books

--- a/olclient/entity_helpers/work.py
+++ b/olclient/entity_helpers/work.py
@@ -126,7 +126,7 @@ def get_work_helper_class(ol_context):
             original_subjects = data.get('subjects', [])
             changed_subjects = merge_unique_lists([original_subjects, subjects])
             data['_comment'] = comment or (
-                'adding %s to subjects' % ', '.join(subjects)
+                f"adding {', '.join(subjects)} to subjects"
             )
             data['subjects'] = changed_subjects
             return self.OL.session.put(url, json.dumps(data))
@@ -135,7 +135,7 @@ def get_work_helper_class(ol_context):
             url = self.OL.base_url + "/works/" + self.olid + ".json"
             r = self.OL.session.get(url)
             data = r.json()
-            data['_comment'] = comment or ('rm subjects: %s' % ', '.join(subjects))
+            data['_comment'] = comment or (f"rm subjects: {', '.join(subjects)}")
             data['subjects'] = list(set(data['subjects']) - set(subjects))
             return self.OL.session.put(url, json.dumps(data))
 
@@ -151,12 +151,12 @@ def get_work_helper_class(ol_context):
             """Saves this work back to Open Library using the JSON API."""
             body = self.json()
             body['_comment'] = comment
-            url = self.OL.base_url + '/works/%s.json' % self.olid
+            url = self.OL.base_url + f'/works/{self.olid}.json'
             return self.OL.session.put(url, json.dumps(body))
 
         @classmethod
         def get(cls, olid: str) -> Work:
-            path = '/works/%s.json' % olid
+            path = f'/works/{olid}.json'
             r = cls.OL.get_ol_response(path)
             return cls(olid, **r.json())
 
@@ -181,7 +181,7 @@ def get_work_helper_class(ol_context):
 
             url = f'{cls.OL.base_url}/search.json?title={title}'
             if author:
-                url += '&author=%s' % author
+                url += f'&author={author}'
 
             @backoff.on_exception(
                 on_giveup=lambda error: logger.exception(

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -131,7 +131,7 @@ class OpenLibrary:
         }
         doc_json = [doc.json() for doc in docs]
         return self.session.post(
-            '%s/api/save_many' % self.base_url, json.dumps(doc_json), headers=headers
+            f'{self.base_url}/api/save_many', json.dumps(doc_json), headers=headers
         )
 
     def delete_many(self, ol_ids: List[str], comment: str) -> Response:
@@ -266,7 +266,7 @@ class OpenLibrary:
                 """Saves this edition back to Open Library using the JSON API."""
                 body = self.json()
                 body['_comment'] = comment
-                url = self.OL.base_url + '/books/%s.json' % self.olid
+                url = self.OL.base_url + f'/books/{self.olid}.json'
                 return self.OL.session.put(url, json.dumps(body))
 
             @classmethod
@@ -357,7 +357,7 @@ class OpenLibrary:
                         # No edition found by bibkey
                         return
 
-                path = '/books/%s.json' % olid
+                path = f'/books/{olid}.json'
                 response = cls.OL.get_ol_response(path)
 
                 try:
@@ -499,7 +499,7 @@ class OpenLibrary:
                 """Saves this author back to Open Library using the JSON API."""
                 body = self.json()
                 body['_comment'] = comment
-                url = self.OL.base_url + '/authors/%s.json' % self.olid
+                url = self.OL.base_url + f'/authors/{self.olid}.json'
                 return self.OL.session.put(url, json.dumps(body))
 
             def works(self, limit=OL.WORKS_LIMIT, offset=OL.WORKS_PAGINATION_OFFSET):
@@ -528,7 +528,7 @@ class OpenLibrary:
                     or
                     >>> ol.Author.get(ol.Author.get_olid_by_name('Dan Brown')).works()
                 """
-                path = '/authors/%s/works.json' % self.olid
+                path = f'/authors/{self.olid}/works.json'
 
                 # check to prevent 'None' value
                 limit = limit or self.OL.WORKS_LIMIT
@@ -560,7 +560,7 @@ class OpenLibrary:
                     >>> ol = OpenLibrary()
                     >>> ol.Author.get('OL39307A')
                 """
-                path = '/authors/%s.json' % olid
+                path = f'/authors/{olid}.json'
                 r = cls.OL.get_ol_response(path)
                 try:
                     data = r.json()
@@ -568,7 +568,7 @@ class OpenLibrary:
                         data.pop('key', ''), url_type='authors'
                     )
                 except:
-                    raise Exception("Unable to get Author with olid: %s" % olid)
+                    raise Exception(f"Unable to get Author with olid: {olid}")
 
                 return cls(
                     olid,
@@ -602,7 +602,7 @@ class OpenLibrary:
                     err = lambda e: logger.exception(
                         "Error fetching author matches: %s", e
                     )
-                    url = cls.OL.base_url + '/authors/_autocomplete?q=%s&limit=%s' % (
+                    url = cls.OL.base_url + '/authors/_autocomplete?q={}&limit={}'.format(
                         name,
                         limit,
                     )
@@ -808,14 +808,13 @@ class OpenLibrary:
         """
         if id_name not in self.VALID_IDS:
             raise ValueError(
-                "Invalid `id_name`. Must be one of %s, got %s"
-                % (self.VALID_IDS, id_name)
+                f"Invalid `id_name`. Must be one of {self.VALID_IDS}, got {id_name}"
             )
 
         err = lambda e: logger.exception("Error creating OpenLibrary " "book: %s", e)
         url = self.base_url + '/books/add'
         if work_olid:
-            url += '?work=/works/%s' % work_olid
+            url += f'?work=/works/{work_olid}'
         data = {
             "title": title,
             "author_name": author_name,
@@ -844,7 +843,7 @@ class OpenLibrary:
         """Returns the .json url for an olid (str)"""
         ol_paths = {'OL..A': 'authors', 'OL..M': 'books', 'OL..W': 'works'}
         kind = re.sub(r'\d+', '..', olid)
-        return "{}/{}/{}.json".format(self.base_url, ol_paths[kind], olid)
+        return f"{self.base_url}/{ol_paths[kind]}/{olid}.json"
 
     @staticmethod
     def get_text_value(text):
@@ -864,13 +863,13 @@ class OpenLibrary:
         try:
             return ol_types[kind]
         except KeyError:
-            raise ValueError("Unknown type for olid: %s" % olid)
+            raise ValueError(f"Unknown type for olid: {olid}")
 
     @staticmethod
     def full_key(olid):
         """Returns the Open Library JSON key of format /<type(plural)>/<olid> as used by the
         Open Library API."""
-        return "/{}s/{}".format(OpenLibrary.get_type(olid), olid)
+        return f"/{OpenLibrary.get_type(olid)}s/{olid}"
 
     @staticmethod
     def _extract_olid_from_url(url, url_type):

--- a/tests/test_book.py
+++ b/tests/test_book.py
@@ -64,17 +64,17 @@ class TestBook(unittest.TestCase):
         book = Book(title="Test Book", authors=["Jane Doe"], publish_date=2015)
         self.assertTrue(
             book.title == "Test Book",
-            "Book title should be %s, instead is %s" % ("Test Book", book.title),
+            f"Book title should be Test Book, instead is {book.title}",
         )
 
         self.assertTrue(
             book.authors[0] == "Jane Doe",
-            "Book author should be %s, instead is %s" % ("Jane Doe", book.authors),
+            f"Book author should be Jane Doe, instead is {book.authors}",
         )
 
         self.assertTrue(
             book.publish_date == 2015,
-            "Book year should be %s, instead is %s" % (2015, book.publish_date),
+            f"Book year should be {2015}, instead is {book.publish_date}",
         )
 
     def test_canonical_title(self):
@@ -84,7 +84,7 @@ class TestBook(unittest.TestCase):
         got = book.canonical_title
         self.assertTrue(
             got == expected,
-            "Title canonicalization expected %s, got %s" % (expected, got),
+            f"Title canonicalization expected {expected}, got {got}",
         )
 
     def test_xisbn_to_books(self):

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -97,7 +97,7 @@ class TestOpenLibrary(unittest.TestCase):
         canonical_title = book.canonical_title
         self.assertTrue(
             'franklin' in canonical_title,
-            "Expected 'franklin' to appear in result title: %s" % canonical_title,
+            f"Expected 'franklin' to appear in result title: {canonical_title}",
         )
 
     @patch('requests.Session.get')
@@ -115,10 +115,10 @@ class TestOpenLibrary(unittest.TestCase):
         book = self.ol.Edition.get(isbn='0374202915')
         mock_get.assert_has_calls(
             [
-                call("%s/api/books.json?bibkeys=ISBN:0374202915" % self.ol.base_url),
+                call(f"{self.ol.base_url}/api/books.json?bibkeys=ISBN:0374202915"),
                 call().raise_for_status(),
                 call().json(),
-                call("{}/books/OL23575801M.json".format(self.ol.base_url)),
+                call(f"{self.ol.base_url}/books/OL23575801M.json"),
                 call().raise_for_status(),
                 call().json(),
             ]
@@ -156,9 +156,7 @@ class TestOpenLibrary(unittest.TestCase):
         mock_get.return_value.json.return_value = author_autocomplete
         got_result = self.ol.create_book(book, debug=True)
         mock_get.assert_called_with(
-            "{}/authors/_autocomplete?q={}&limit=1".format(
-                self.ol.base_url, "Karl Schwarzer"
-            )
+            f"{self.ol.base_url}/authors/_autocomplete?q=Karl Schwarzer&limit=1"
         )
         expected_result = {
             '_save': '',
@@ -172,7 +170,7 @@ class TestOpenLibrary(unittest.TestCase):
         }
         self.assertTrue(
             got_result == expected_result,
-            "Expected create_book to return %s, got %s" % (expected_result, got_result),
+            f"Expected create_book to return {expected_result}, got {got_result}",
         )
 
     def test_get_work(self):
@@ -255,7 +253,7 @@ class TestOpenLibrary(unittest.TestCase):
         mock_get.return_value.raise_for_status = raise_http_error
         suffixes = {'edition': 'M', 'work': 'W', 'author': 'A'}
         for _type, suffix in suffixes.items():
-            target = "OLnotfound%s" % suffix
+            target = f"OLnotfound{suffix}"
             with pytest.raises(requests.HTTPError):
                 r = self.ol.get(target)
                 pytest.fail(f"HTTPError not raised for {_type}: {target}")
@@ -268,7 +266,7 @@ class TestOpenLibrary(unittest.TestCase):
         work = self.ol.Work(olid='OL12W', title='minimal work')
         self.ol.save_many([edition, work], "test comment")
         mock_post.assert_called_with(
-            "%s/api/save_many" % self.ol.base_url, ANY, headers=ANY
+            f"{self.ol.base_url}/api/save_many", ANY, headers=ANY
         )
         called_with_json = json.loads(mock_post.call_args[0][1])
         called_with_headers = mock_post.call_args[1]['headers']
@@ -347,7 +345,7 @@ class TestFullEditionGet(unittest.TestCase):
                 call(f"{self.ol.base_url}/books/{self.target_olid}.json"),
                 call().raise_for_status(),
                 call().json(),
-                call("%s/authors/OL440500A.json" % self.ol.base_url),
+                call(f"{self.ol.base_url}/authors/OL440500A.json"),
                 call().raise_for_status(),
                 call().json(),
             ]
@@ -374,7 +372,7 @@ class TestFullEditionGet(unittest.TestCase):
                 call(f"{self.ol.base_url}/books/{self.target_olid}.json"),
                 call().raise_for_status(),
                 call().json(),
-                call("%s/authors/OL440500A.json" % self.ol.base_url),
+                call(f"{self.ol.base_url}/authors/OL440500A.json"),
                 call().raise_for_status(),
                 call().json(),
             ]


### PR DESCRIPTION
Use [`pyupgrade --py37-plus --keep-runtime-typing **/*.py`](https://pypi.org/project/pyupgrade) and [`flynt .`](https://pypi.org/project/flynt) to convert to Python f-strings which are easier to read and faster.  https://www.scivision.dev/python-f-string-speed