### PR TITLE
Upgrade olclient.__version__ which is < pypi version

### DIFF
--- a/olclient/__init__.py
+++ b/olclient/__init__.py
@@ -9,7 +9,7 @@
 """
 
 __title__ = 'olclient'
-__version__ = '0.0.20'
+__version__ = '0.0.31'
 __author__ = 'Internet Archive'
 
 


### PR DESCRIPTION
The code on the repo is later than, not earlier than the code on PyPI.

Currently [`pipx`](https://pypi.org/project/pipx) installing from the repo is ___v0.0.20___ but the [Oct 2020 release on PyPI](https://pypi.org/project/openlibrary-client) is ___v0.0.30___.

$ `pipx install openlibrary-client`
```
  installed package openlibrary-client 0.0.30, installed using Python 3.9.13
```
$ `pipx install git+https://github.com/internetarchive/openlibrary-client.git`
```
  installed package openlibrary-client 0.0.20, installed using Python 3.9.13
```
### Testing
$ `pipx install git+https://github.com/internetarchive/openlibrary-client.git@olclient.__version__-=-0.0.31`
```
  installed package openlibrary-client 0.0.31, installed using Python 3.9.13
```