### PR TITLE
pipx install git+https://github.com/internetarchive/openlibrary-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A reference client library for the Open Library API. Tested with Python 3.7, 3.8
 
 To install the openlibrary-client package:
 ```
+$ pipx install git+https://github.com/internetarchive/openlibrary-client.git
+```
+__-- or --__
+```
 $ git clone https://github.com/internetarchive/openlibrary-client.git
 $ cd openlibrary-client
 $ pip install .


### PR DESCRIPTION
https://pypa.github.io/pipx/#installing-from-source-control Replaces the current three-step installation process with a single-step process and keeps `ol` in its own virtualenv that can be upgraded anytime with `pipx upgrade-all` 