### PR TITLE
Languages schema updates

### DIFF
--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -74,6 +74,16 @@
       "type": "array",
       "items": { "$ref": "#/definitions/language" }
     },
+    "translated_from": {
+      "type": "array",
+      "description": "Translated from original language(s)",
+      "items": { "$ref": "#/definitions/language" }
+    },
+    "translation_of": {
+      "type": "string",
+      "description": "The title of the original language work",
+      "examples": [ "Ai margini del caos" ]
+    },
     "by_statement": { "type": "string" },
     "weight": {
       "type": "string",
@@ -166,7 +176,7 @@
         }
       }
     },
-    "languages": {
+    "language": {
       "type": "object",
       "required": [ "key" ],
       "additionalProperties": false,
@@ -178,24 +188,6 @@
 	  "examples": [ "/languages/eng", "/languages/ger" ]
         }
       }
-    },
-    "translated_from": {
-      "type": "object",
-      "required": [ "key" ],
-      "additionalProperties": false,
-      "description": "Translated from original language(s). Uses the same language format as 'languages'",
-      "properties": {
-        "key": {
-          "type": "string",
-          "pattern": "^/languages/[a-z]{3}$",
-	  "examples": [ "/languages/fre" ]
-        }
-      }
-    },
-    "translation_of": {
-      "type": "string",
-      "description": "The title of the original language work",
-      "example": "Ai margini del caos"
     }
   }
 }

--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -174,9 +174,28 @@
       "properties": {
         "key": {
           "type": "string",
-          "pattern": "^/languages/[a-z]{3}$"
+          "pattern": "^/languages/[a-z]{3}$",
+	  "examples": [ "/langauges/eng", "/languages/ger" ]
         }
       }
+    },
+    "translation_from": {
+      "type": "object",
+      "required": [ "key" ],
+      "additionalProperties": false,
+      "description": "Translated from original language(s). Uses the same language format as 'languages'",
+      "properties": {
+        "key": {
+          "type": "string",
+          "pattern": "^/languages/[a-z]{3}$",
+	  "examples": [ "/languages/fre" ]
+        }
+      }
+    },
+    "translation_of": {
+      "type": "string",
+      "description": "The title of the original language work",
+      "example": "Ai margini del caos"
     }
   }
 }

--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -166,7 +166,7 @@
         }
       }
     },
-    "language": {
+    "languages": {
       "type": "object",
       "required": [ "key" ],
       "additionalProperties": false,

--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -179,7 +179,7 @@
         }
       }
     },
-    "translation_from": {
+    "translated_from": {
       "type": "object",
       "required": [ "key" ],
       "additionalProperties": false,

--- a/olclient/schemata/edition.schema.json
+++ b/olclient/schemata/edition.schema.json
@@ -175,7 +175,7 @@
         "key": {
           "type": "string",
           "pattern": "^/languages/[a-z]{3}$",
-	  "examples": [ "/langauges/eng", "/languages/ger" ]
+	  "examples": [ "/languages/eng", "/languages/ger" ]
         }
       }
     },

--- a/olclient/schemata/import.schema.json
+++ b/olclient/schemata/import.schema.json
@@ -37,6 +37,13 @@
       "type": "array",
       "items": { "$ref": "shared_definitions.json#/language_code" }
     },
+    "translated_from": {
+      "type": "array",
+      "items": { "$ref": "shared_definitions.json#/language_code" }
+    },
+    "translation_of": {
+      "type": "string"
+    },
     "isbn_10": {
       "type": "array",
       "items": { "$ref": "edition.schema.json#/definitions/isbn_10" }


### PR DESCRIPTION
This PR closes #342 

## Description:

Correct the edition schema `languages` field name (#135 )

Adds `translated_from` and `translation_of` fields to the edition schema and import schema.
