### PR TITLE
Add C# library to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,9 @@ $ pytest
 ## Other Client Libraries
 
 Other Open Library client libraries include:
+- C#: https://github.com/Luca3317/OpenLibrary.NET
 - Go: https://github.com/Open-pi/gol
 - Javascript: https://github.com/onaclovtech/openlibrary
 - PHP: https://github.com/beezus/openlibrary-php
 - Python: https://github.com/felipeborges/python-openlibrary and https://github.com/the-metalgamer/python-openlibrary-client
 - Ruby: https://github.com/jayfajardo/openlibrary
-- C#: https://github.com/Luca3317/OpenLibrary.NET

--- a/README.md
+++ b/README.md
@@ -165,3 +165,4 @@ Other Open Library client libraries include:
 - PHP: https://github.com/beezus/openlibrary-php
 - Python: https://github.com/felipeborges/python-openlibrary and https://github.com/the-metalgamer/python-openlibrary-client
 - Ruby: https://github.com/jayfajardo/openlibrary
+- C#: https://github.com/Luca3317/OpenLibrary.NET


### PR DESCRIPTION
This hasn't been vetted by anyone yet, but was mentioned during our community call today.

Linked repo: https://github.com/Luca3317/OpenLibrary.NET

**Edit:** Should we ask Luca3317 before adding their library to the README?