### PR TITLE
Remove deprecated and unused field `id` on Work

### DIFF
--- a/olclient/schemata/work.schema.json
+++ b/olclient/schemata/work.schema.json
@@ -36,10 +36,6 @@
       "type": "array",
       "items": { "$ref": "shared_definitions.json#/link" }
     },
-    "id": {
-      "description": "Unsure what this is for, deprecate?",
-      "type": "number"
-     },
     "lc_classifications":  { "$ref": "shared_definitions.json#/string_array" },
     "subjects":            { "$ref": "shared_definitions.json#/string_array" },
 


### PR DESCRIPTION


## Description:
'id' on Works has no documented use and is confusing. Removing it from the schema documentation.