### PR TITLE
fix(schema): replace deprecated jsonschema.RefResolver with referencing.Registry

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -11,6 +11,8 @@ import re
 from urllib.parse import urlencode
 from urllib.request import pathname2url
 
+from referencing import Registry, Resource
+
 import backoff
 import requests
 from requests import Response
@@ -21,6 +23,28 @@ from olclient.entity_helpers.work import get_work_helper_class
 from olclient.utils import merge_unique_lists
 
 logger = logging.getLogger('openlibrary')
+
+
+def _schema_uri(path: str) -> str:
+    """Return a canonical file:// URI for an absolute schema path."""
+    return 'file:' + pathname2url(os.path.realpath(path))
+
+
+def _build_schema_registry(schemata_dir: str) -> Registry:
+    """Build a referencing.Registry containing all JSON schemas in schemata_dir.
+
+    Registers each .json file under a file:// URI so that cross-schema
+    $ref resolution works without the deprecated jsonschema.RefResolver.
+    """
+    resources = {}
+    for fname in os.listdir(schemata_dir):
+        if not fname.endswith('.json'):
+            continue
+        fpath = os.path.join(schemata_dir, fname)
+        with open(fpath, encoding='utf-8') as f:
+            schema = json.load(f)
+        resources[_schema_uri(fpath)] = Resource.from_contents(schema)
+    return Registry().with_resources(resources.items())
 
 
 class OpenLibrary:
@@ -102,13 +126,15 @@ class OpenLibrary:
           jsonschema.exceptions.ValidationError if validation fails.
         """
         path = os.path.dirname(os.path.realpath(__file__))
-        schemata_path = os.path.join(path, 'schemata', schema_name)
+        schemata_dir = os.path.join(path, 'schemata')
+        schemata_path = os.path.join(schemata_dir, schema_name)
         with open(schemata_path) as schema_data:
             schema = json.load(schema_data)
-            resolver = jsonschema.RefResolver('file:' + pathname2url(schemata_path), schema)
-            return jsonschema.Draft4Validator(schema, resolver=resolver).validate(
-                doc.json()
-            )
+        registry = _build_schema_registry(schemata_dir)
+        # Inject the schema's own URI as `id` so relative $refs resolve correctly.
+        # Draft4Validator uses `id` (not `$id`) as the base URI for the resolver.
+        schema.setdefault('id', _schema_uri(schemata_path))
+        return jsonschema.Draft4Validator(schema, registry=registry).validate(doc.json())
 
     def delete(self, olid, comment):
         """Delete a single Open Library entity by olid (str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,7 @@ norecursedirs = ["lib*"]
 [tool.ruff]
 extend-select = ["C4", "C9", "PLC", "PLE", "W"]
 ignore = ["E703", "E722", "E731", "F401", "E402"]
-line-length=1501
-show-source = true
+line-length = 1501
 target-version = "py37"
 
 [tool.ruff.mccabe]

--- a/tests/schemata/test_import_schema.py
+++ b/tests/schemata/test_import_schema.py
@@ -1,12 +1,29 @@
 import json
-from nturl2path import pathname2url
 import jsonschema
 import os
 import pytest
+from referencing import Registry, Resource
+from urllib.request import pathname2url
 
-IMPORT_SCHEMA = os.path.join(
-    os.path.dirname(__file__), '..', '..', 'olclient', 'schemata', 'import.schema.json'
-)
+SCHEMATA_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'olclient', 'schemata')
+IMPORT_SCHEMA = os.path.join(SCHEMATA_DIR, 'import.schema.json')
+
+
+def _schema_uri(path):
+    return 'file:' + pathname2url(os.path.realpath(path))
+
+
+def _build_schema_registry(schemata_dir):
+    """Build a Registry containing all JSON schemas in schemata_dir."""
+    resources = {}
+    for fname in os.listdir(schemata_dir):
+        if not fname.endswith('.json'):
+            continue
+        fpath = os.path.join(schemata_dir, fname)
+        with open(fpath, encoding='utf-8') as f:
+            schema = json.load(f)
+        resources[_schema_uri(fpath)] = Resource.from_contents(schema)
+    return Registry().with_resources(resources.items())
 
 # Examples taken from openlibrary/plugins/importapi/import_edition_builder.py
 
@@ -89,8 +106,9 @@ examples = [
 
 @pytest.mark.parametrize('example', examples)
 def test_import_examples(example):
-    with open(IMPORT_SCHEMA) as schema_data:
+    with open(IMPORT_SCHEMA, encoding='utf-8') as schema_data:
         schema = json.load(schema_data)
-        resolver = jsonschema.RefResolver('file:' + pathname2url(IMPORT_SCHEMA), schema)
-        result = jsonschema.Draft4Validator(schema, resolver=resolver).validate(example)
-        assert result is None
+    registry = _build_schema_registry(SCHEMATA_DIR)
+    schema.setdefault('id', _schema_uri(IMPORT_SCHEMA))
+    result = jsonschema.Draft4Validator(schema, registry=registry).validate(example)
+    assert result is None


### PR DESCRIPTION
## Summary

`jsonschema.RefResolver` was deprecated in v4.18.0 and the warning fires on every `ol.validate()` call. This PR replaces it with the `referencing.Registry` API.

## Changes

- **`olclient/openlibrary.py`**: Add `_schema_uri()` helper and `_build_schema_registry()` that pre-loads all `schemata/*.json` files into a `Registry`. The `validate()` method now injects the schema's own `id` (Draft4's base URI field) before calling `Draft4Validator(..., registry=registry)`, so relative `$ref` values like `shared_definitions.json#/string_array` resolve correctly.
- **`tests/schemata/test_import_schema.py`**: Same pattern — uses `_build_schema_registry` + injected `id` instead of `RefResolver`.
- **`pyproject.toml`**: Remove `show-source = true` from `[tool.ruff]` — this option was removed in modern ruff and causes a config error.

## Testing

```
$ pytest tests/ -q
46 passed, 4 warnings
```

The 4 remaining warnings are from `backoff`'s internal use of `asyncio.iscoroutinefunction` (a third-party package deprecation in Python 3.14, not actionable here). Zero `jsonschema` or `RefResolver` deprecation warnings.

## Note on cross-schema `$ref` resolution

The tricky part: `import.schema.json` references `shared_definitions.json` and `edition.schema.json` via relative `$ref`. The old `RefResolver` resolved these relative to the base URI directory automatically. The new `Registry` requires all referenced schemas to be pre-loaded AND the root schema needs an `id` field set to its own URI so `Draft4Validator`'s internal `Resolver` has a non-empty base URI to resolve relative paths against.

Relates to open PR #430 (same issue, different implementation).