### PR TITLE
feat(client): add from_local(), env var credentials, health_check()

### DIFF
--- a/olclient/__init__.py
+++ b/olclient/__init__.py
@@ -16,3 +16,4 @@ __author__ = 'Internet Archive'
 from olclient.bots import AbstractBotJob
 from olclient.openlibrary import OpenLibrary
 from olclient.common import Book, Author
+from olclient.config import Credentials, UserCredentials

--- a/olclient/config.py
+++ b/olclient/config.py
@@ -31,6 +31,7 @@ def getdef(self, section, option, default_value):
 
 
 Credentials = namedtuple('Credentials', ['access', 'secret'])
+UserCredentials = namedtuple('UserCredentials', ['username', 'password'])
 
 
 class Config:

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -16,7 +16,7 @@ import requests
 from requests import Response
 
 from olclient import common
-from olclient.config import Config
+from olclient.config import Config, Credentials, UserCredentials
 from olclient.entity_helpers.work import get_work_helper_class
 from olclient.utils import merge_unique_lists
 
@@ -61,12 +61,56 @@ class OpenLibrary:
     WORKS_LIMIT = 50
     WORKS_PAGINATION_OFFSET = 0
 
-    def __init__(self, credentials=None, base_url='https://openlibrary.org'):
+    def __init__(self, credentials=None, base_url=None):
         self.session = requests.Session()
-        self.base_url = base_url
-        credentials = credentials or Config().get_config().get('s3', None)
+        self.base_url = base_url or os.environ.get('OL_BASE_URL', 'https://openlibrary.org')
+        if credentials is None:
+            # Env var credentials take precedence over config file
+            username = os.environ.get('OL_USERNAME')
+            password = os.environ.get('OL_PASSWORD')
+            s3_access = os.environ.get('OL_S3_ACCESS')
+            s3_secret = os.environ.get('OL_S3_SECRET')
+            if username and password:
+                credentials = UserCredentials(username=username, password=password)
+            elif s3_access and s3_secret:
+                credentials = Credentials(access=s3_access, secret=s3_secret)
+            else:
+                credentials = Config().get_config().get('s3', None)
         if credentials:
             self.login(credentials)
+
+    @classmethod
+    def from_local(cls, port=8080, username=None, password=None):
+        """Create an OpenLibrary client pointed at a local Docker dev instance.
+
+        Args:
+            port (int): port the local OL web server is listening on (default 8080)
+            username (str): OL account username/email (optional)
+            password (str): OL account password (optional)
+
+        Returns:
+            OpenLibrary: client instance connected to http://localhost:{port}
+
+        Example:
+            >>> ol = OpenLibrary.from_local()
+            >>> ol = OpenLibrary.from_local(port=8081, username='admin@example.com', password='secret')
+        """
+        creds = UserCredentials(username=username, password=password) if username and password else None
+        return cls(credentials=creds, base_url=f'http://localhost:{port}')
+
+    def health_check(self):
+        """Verify the OL instance is reachable.
+
+        Returns True if the instance responds (any HTTP status), False on connection error.
+        Useful in tests and scripts before performing operations.
+        """
+        try:
+            response = self.session.get(
+                f'{self.base_url}/api/books.json', params={'bibkeys': 'ISBN:0000000000'}, timeout=5
+            )
+            return response.status_code < 500
+        except requests.exceptions.RequestException:
+            return False
 
     def login(self, credentials):
         """Login to Open Library with given credentials, ensures the requests

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -421,3 +421,65 @@ class TestTextType(unittest.TestCase):
         self.assertIsInstance(work.description, str)
         self.assertIn('type', work.json()['description'])
         self.assertEqual(work.json()['description']['value'], "A Text Description")
+
+
+class TestLocalDev(unittest.TestCase):
+    """Tests for local dev ergonomics: from_local(), env vars, health_check()."""
+
+    @patch('olclient.config.Config.get_config', return_value={'s3': None})
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def test_from_local_default_port(self, mock_login, mock_config):
+        ol = OpenLibrary.from_local()
+        self.assertEqual(ol.base_url, 'http://localhost:8080')
+        mock_login.assert_not_called()
+
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def test_from_local_custom_port(self, mock_login):
+        ol = OpenLibrary.from_local(port=8081)
+        self.assertEqual(ol.base_url, 'http://localhost:8081')
+
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def test_from_local_with_credentials(self, mock_login):
+        ol = OpenLibrary.from_local(username='admin@example.com', password='secret')
+        self.assertEqual(ol.base_url, 'http://localhost:8080')
+        mock_login.assert_called_once()
+
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def test_env_var_base_url(self, mock_login):
+        with patch.dict('os.environ', {'OL_BASE_URL': 'http://testserver:9000'}):
+            ol = OpenLibrary()
+        self.assertEqual(ol.base_url, 'http://testserver:9000')
+
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def test_env_var_username_password(self, mock_login):
+        envs = {'OL_USERNAME': 'user@example.com', 'OL_PASSWORD': 'pass'}
+        with patch.dict('os.environ', envs):
+            ol = OpenLibrary()
+        mock_login.assert_called_once()
+        args = mock_login.call_args[0][0]
+        self.assertEqual(args.username, 'user@example.com')
+        self.assertEqual(args.password, 'pass')
+
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def test_env_var_s3_credentials(self, mock_login):
+        envs = {'OL_S3_ACCESS': 'MYACCESS', 'OL_S3_SECRET': 'MYSECRET'}
+        with patch.dict('os.environ', envs):
+            ol = OpenLibrary()
+        mock_login.assert_called_once()
+        args = mock_login.call_args[0][0]
+        self.assertEqual(args.access, 'MYACCESS')
+        self.assertEqual(args.secret, 'MYSECRET')
+
+    @patch('requests.Session.get')
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def test_health_check_true(self, mock_login, mock_get):
+        ol = OpenLibrary()
+        mock_get.return_value.status_code = 200
+        self.assertTrue(ol.health_check())
+
+    @patch('requests.Session.get')
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def test_health_check_false_on_connection_error(self, mock_login, mock_get):
+        ol = OpenLibrary()
+        mock_get.side_effect = requests.exceptions.ConnectionError("refused")
+        self.assertFalse(ol.health_check())

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -454,7 +454,7 @@ class TestLocalDev(unittest.TestCase):
     def test_env_var_username_password(self, mock_login):
         envs = {'OL_USERNAME': 'user@example.com', 'OL_PASSWORD': 'pass'}
         with patch.dict('os.environ', envs):
-            ol = OpenLibrary()
+            OpenLibrary()
         mock_login.assert_called_once()
         args = mock_login.call_args[0][0]
         self.assertEqual(args.username, 'user@example.com')
@@ -464,7 +464,7 @@ class TestLocalDev(unittest.TestCase):
     def test_env_var_s3_credentials(self, mock_login):
         envs = {'OL_S3_ACCESS': 'MYACCESS', 'OL_S3_SECRET': 'MYSECRET'}
         with patch.dict('os.environ', envs):
-            ol = OpenLibrary()
+            OpenLibrary()
         mock_login.assert_called_once()
         args = mock_login.call_args[0][0]
         self.assertEqual(args.access, 'MYACCESS')


### PR DESCRIPTION
## Summary

Makes `openlibrary-client` easier to use with a local Docker dev instance, and removes the requirement that credentials live in a config file.

## Changes

### `olclient/config.py`
- Add `UserCredentials = namedtuple('UserCredentials', ['username', 'password'])` — the `login()` method already handled username/password namedtuples but there was no named type to import

### `olclient/openlibrary.py`
- `OpenLibrary.__init__` now reads env vars before falling back to config file:
  - `OL_BASE_URL` — override the default `https://openlibrary.org`
  - `OL_USERNAME` + `OL_PASSWORD` — username/password login
  - `OL_S3_ACCESS` + `OL_S3_SECRET` — S3 key login
- `OpenLibrary.from_local(port=8080, username=None, password=None)` — classmethod that points the client at `http://localhost:{port}`, for quick local dev setup
- `OpenLibrary.health_check()` — returns `True` if the instance is reachable, `False` on connection error; useful in test scripts

### `olclient/__init__.py`
- Export `Credentials` and `UserCredentials` from the top-level package

## Usage

```python
# Quick local dev setup
ol = OpenLibrary.from_local()  # → http://localhost:8080
ol = OpenLibrary.from_local(port=8081, username='admin@ol.org', password='secret')

# Env var driven (CI, containers)
# OL_BASE_URL=http://localhost:8080 OL_USERNAME=... OL_PASSWORD=... python script.py
ol = OpenLibrary()  # picks up env vars automatically

# Reachability check
if not ol.health_check():
    raise RuntimeError("OL instance not available")
```

## Testing

```
$ pytest tests/ -q
54 passed, 16 warnings
```

8 new unit tests cover `from_local()`, env var precedence (base URL, username/password, S3), and `health_check()` true/false paths.