### PR TITLE
feat(client): add get_many() and get_many_by_isbn() bulk fetch

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -751,6 +751,86 @@ class OpenLibrary:
         elif _olid.endswith('a'):
             return self.Author.get(olid)
 
+    def get_many(self, olids):
+        """Fetch multiple OL entities by OLID in a single API call.
+
+        Uses /api/get_many.json with comma-separated full keys.
+        Documents not found in OL are silently skipped.
+
+        Args:
+            olids (list[str]) - OLIDs, e.g. ['OL45804W', 'OL1526129M', 'OL26170A']
+
+        Returns:
+            list - typed objects (Work, Edition, or Author) in response order
+
+        Raises:
+            ValueError if any OLID has an unrecognized type suffix
+
+        Usage:
+            >>> results = ol.get_many(['OL45804W', 'OL1526129M'])
+        """
+        if not olids:
+            return []
+        keys = [self.full_key(olid) for olid in olids]
+        path = '/api/get_many.json?keys=' + ','.join(keys)
+        response = self.get_ol_response(path)
+        data = response.json()
+        results = []
+        for key, doc in data.items():
+            if doc is None:
+                continue
+            olid = key.split('/')[-1]
+            _type = olid[-1].upper()
+            if _type == 'W':
+                results.append(self.Work(olid, **doc))
+            elif _type == 'M':
+                results.append(
+                    self.Edition(**self.Edition.ol_edition_json_to_book_args(doc))
+                )
+            elif _type == 'A':
+                _olid = self._extract_olid_from_url(
+                    doc.pop('key', ''), url_type='authors'
+                )
+                results.append(
+                    self.Author(
+                        _olid or olid,
+                        name=doc.pop('name', ''),
+                        bio=self.get_text_value(doc.pop('bio', None)),
+                        **doc,
+                    )
+                )
+        return results
+
+    def get_many_by_isbn(self, isbns):
+        """Fetch multiple editions by ISBN in two API calls.
+
+        Resolves ISBNs to OLIDs via /api/books.json (one call), then
+        fetches full edition data via /api/get_many.json (one call).
+
+        Args:
+            isbns (list[str]) - ISBN-10 or ISBN-13 values
+
+        Returns:
+            list of Edition objects (only editions found in OL)
+
+        Usage:
+            >>> ol.get_many_by_isbn(['0374202915', '9780525521198'])
+        """
+        if not isbns:
+            return []
+        bibkeys = ','.join(f'ISBN:{isbn}' for isbn in isbns)
+        path = f'/api/books.json?bibkeys={bibkeys}'
+        metadata = self.get_ol_response(path).json()
+        olids = []
+        for entry in metadata.values():
+            info_url = entry.get('info_url', '')
+            olid = self._extract_olid_from_url(info_url, url_type='books')
+            if olid:
+                olids.append(olid)
+        if not olids:
+            return []
+        return self.get_many(olids)
+
     @classmethod
     def get_primary_identifier(cls, book):
         """XXX needs docs"""

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -386,6 +386,117 @@ class TestFullEditionGet(unittest.TestCase):
         )
 
 
+class TestGetMany(unittest.TestCase):
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def setUp(self, mock_login):
+        self.ol = OpenLibrary()
+
+    @patch('requests.Session.get')
+    def test_get_many_empty_returns_empty(self, mock_get):
+        results = self.ol.get_many([])
+        assert results == []
+        mock_get.assert_not_called()
+
+    @patch('requests.Session.get')
+    def test_get_many_returns_work(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            '/works/OL45804W': {
+                'key': '/works/OL45804W',
+                'title': 'Harry Potter',
+                'type': {'key': '/type/work'},
+            }
+        }
+        results = self.ol.get_many(['OL45804W'])
+        assert len(results) == 1
+        assert results[0].olid == 'OL45804W'
+        assert results[0].title == 'Harry Potter'
+
+    @patch('requests.Session.get')
+    def test_get_many_skips_null_docs(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            '/works/OL45804W': {
+                'key': '/works/OL45804W',
+                'title': 'Harry Potter',
+            },
+            '/works/OL99999W': None,
+        }
+        results = self.ol.get_many(['OL45804W', 'OL99999W'])
+        assert len(results) == 1
+
+    @patch('requests.Session.get')
+    def test_get_many_returns_edition(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            '/books/OL1526129M': {
+                'key': '/books/OL1526129M',
+                'title': "Artificial Intelligence",
+                'works': [{'key': '/works/OL82563W'}],
+            }
+        }
+        results = self.ol.get_many(['OL1526129M'])
+        assert len(results) == 1
+        assert results[0].olid == 'OL1526129M'
+        assert results[0].title == 'Artificial Intelligence'
+        assert results[0].work_olid == 'OL82563W'
+
+    @patch('requests.Session.get')
+    def test_get_many_returns_author(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            '/authors/OL26170A': {
+                'key': '/authors/OL26170A',
+                'name': 'Benjamin Franklin',
+                'type': {'key': '/type/author'},
+            }
+        }
+        results = self.ol.get_many(['OL26170A'])
+        assert len(results) == 1
+        assert results[0].olid == 'OL26170A'
+        assert results[0].name == 'Benjamin Franklin'
+
+    @patch('requests.Session.get')
+    def test_get_many_constructs_correct_url(self, mock_get):
+        mock_get.return_value.json.return_value = {}
+        self.ol.get_many(['OL45804W', 'OL1526129M'])
+        called_url = mock_get.call_args[0][0]
+        assert '/api/get_many.json?keys=' in called_url
+        assert '/works/OL45804W' in called_url
+        assert '/books/OL1526129M' in called_url
+
+    @patch('requests.Session.get')
+    def test_get_many_by_isbn_empty_returns_empty(self, mock_get):
+        results = self.ol.get_many_by_isbn([])
+        assert results == []
+        mock_get.assert_not_called()
+
+    @patch('requests.Session.get')
+    def test_get_many_by_isbn_fetches_editions(self, mock_get):
+        books_api_response = {
+            'ISBN:0374202915': {
+                'info_url': 'https://openlibrary.org/books/OL23575801M/Marie_LaVeau'
+            }
+        }
+        get_many_response = {
+            '/books/OL23575801M': {
+                'key': '/books/OL23575801M',
+                'title': 'Marie LaVeau',
+                'works': [{'key': '/works/OL1W'}],
+            }
+        }
+        mock_get.return_value.json.side_effect = [books_api_response, get_many_response]
+        results = self.ol.get_many_by_isbn(['0374202915'])
+        assert len(results) == 1
+        assert results[0].olid == 'OL23575801M'
+        assert results[0].title == 'Marie LaVeau'
+        assert results[0].work_olid == 'OL1W'
+
+    @patch('requests.Session.get')
+    def test_get_many_by_isbn_constructs_bibkeys(self, mock_get):
+        mock_get.return_value.json.side_effect = [{}, {}]
+        self.ol.get_many_by_isbn(['0374202915', '9780525521198'])
+        called_url = mock_get.call_args_list[0][0][0]
+        assert 'ISBN:0374202915' in called_url
+        assert 'ISBN:9780525521198' in called_url
+
+
 class TestTextType(unittest.TestCase):
     @patch('olclient.openlibrary.OpenLibrary.login')
     def setUp(self, mock_login):


### PR DESCRIPTION
## Summary

Adds two new methods to `OpenLibrary` for bulk entity fetching:

### `ol.get_many(olids)`

Fetches any mix of Works, Editions, and Authors in a **single** `/api/get_many.json` call. Returns a list of typed objects in response order. Documents not found in OL are silently skipped.

```python
results = ol.get_many(['OL45804W', 'OL1526129M', 'OL26170A'])
# → [Work, Edition, Author]
```

### `ol.get_many_by_isbn(isbns)`

Resolves ISBNs → OLIDs via one `/api/books.json` call, then fetches full Edition data via `get_many()`. **Two total HTTP calls** regardless of batch size.

```python
editions = ol.get_many_by_isbn(['0374202915', '9780525521198'])
```

## Why

Single-entity fetches (`Work.get()`, `Edition.get()`) make one HTTP request per entity. For import pipelines and bulk enrichment, this is prohibitive. The `/api/get_many.json` endpoint already exists on OL and supports hundreds of keys per request.

## Testing

```
pytest tests/ -x -v
55 passed in 0.17s
```

- 9 new unit tests in `TestGetMany` covering: empty input, Work/Edition/Author dispatch, null-doc skipping, URL construction, and `get_many_by_isbn` ISBN→OLID resolution
- `pre-commit run --files` clean

## Related

Part of a series making `openlibrary-client` production-ready for local Docker dev and bulk operations:
- PR #438: Fix CI deprecations (merged)
- PR #439: Local dev ergonomics — `from_local()`, env vars, `health_check()` (open)
- **This PR**: Bulk fetch
- Next: Integration test infrastructure, Tag entity

Closes #440