### PR TITLE
test(client): add integration test infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ show_error_context = true
 
 [tool.pytest.ini_options]
 norecursedirs = ["lib*"]
+markers = [
+    "integration: requires a running OL instance (set OL_TEST_URL)",
+]
 
 [tool.ruff]
 extend-select = ["C4", "C9", "PLC", "PLE", "W"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+"""
+Pytest fixtures for integration tests.
+
+Integration tests require a running OL instance (local Docker or staging).
+They are skipped unless OL_TEST_URL is set:
+
+    OL_TEST_URL=http://localhost:8080 pytest tests/integration/ -m integration
+
+For write tests, also set:
+    OL_USERNAME=openlibrary@example.com
+    OL_PASSWORD=admin123
+"""
+
+import os
+
+import pytest
+
+from olclient.openlibrary import OpenLibrary
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "integration: requires a running OL instance (set OL_TEST_URL)",
+    )
+
+
+@pytest.fixture(scope="session")
+def ol_local():
+    """Return an OpenLibrary client pointed at OL_TEST_URL.
+
+    Skips the test if OL_TEST_URL is not set. Logs in if OL_USERNAME
+    and OL_PASSWORD are also set.
+    """
+    url = os.environ.get("OL_TEST_URL")
+    if not url:
+        pytest.skip("OL_TEST_URL not set — skipping integration tests")
+
+    ol = OpenLibrary(base_url=url)
+
+    username = os.environ.get("OL_USERNAME")
+    password = os.environ.get("OL_PASSWORD")
+    if username and password:
+        from olclient.config import Credentials
+
+        ol.login(Credentials(username, password))
+
+    return ol

--- a/tests/integration/test_fetch.py
+++ b/tests/integration/test_fetch.py
@@ -1,0 +1,105 @@
+"""
+Integration tests for read/fetch operations.
+
+These tests require a running OL instance. Run with:
+
+    OL_TEST_URL=http://localhost:8080 pytest tests/integration/test_fetch.py -m integration -v
+
+Known-stable OL entities used below (from openlibrary.org production):
+  - Work:    OL45804W   (Harry Potter and the Philosopher's Stone)
+  - Edition: OL7353617M (same work, English edition)
+  - Author:  OL23919A   (J. K. Rowling)
+"""
+
+import pytest
+
+
+@pytest.mark.integration
+class TestWorkFetch:
+    def test_get_work_by_olid(self, ol_local):
+        w = ol_local.Work.get('OL45804W')
+        assert w is not None
+        assert w.olid == 'OL45804W'
+        assert w.title
+
+    def test_get_work_has_authors(self, ol_local):
+        w = ol_local.Work.get('OL45804W')
+        assert isinstance(w.authors, list)
+
+    def test_get_nonexistent_work_returns_none(self, ol_local):
+        w = ol_local.Work.get('OL9999999999W')
+        assert w is None
+
+
+@pytest.mark.integration
+class TestEditionFetch:
+    def test_get_edition_by_olid(self, ol_local):
+        e = ol_local.Edition.get('OL7353617M')
+        assert e is not None
+        assert e.olid == 'OL7353617M'
+        assert e.title
+
+    def test_get_edition_by_isbn(self, ol_local):
+        e = ol_local.Edition.get(isbn='9780439708180')
+        assert e is not None
+        assert e.title
+
+    def test_get_nonexistent_edition_returns_none(self, ol_local):
+        e = ol_local.Edition.get('OL9999999999M')
+        assert e is None
+
+
+@pytest.mark.integration
+class TestAuthorFetch:
+    def test_get_author_by_olid(self, ol_local):
+        a = ol_local.Author.get('OL23919A')
+        assert a is not None
+        assert a.olid == 'OL23919A'
+        assert a.name
+
+    def test_get_nonexistent_author_returns_none(self, ol_local):
+        a = ol_local.Author.get('OL9999999999A')
+        assert a is None
+
+
+@pytest.mark.integration
+class TestGenericGet:
+    def test_get_dispatches_to_work(self, ol_local):
+        result = ol_local.get('OL45804W')
+        assert result is not None
+        assert result.olid == 'OL45804W'
+
+    def test_get_dispatches_to_edition(self, ol_local):
+        result = ol_local.get('OL7353617M')
+        assert result is not None
+        assert result.olid == 'OL7353617M'
+
+    def test_get_dispatches_to_author(self, ol_local):
+        result = ol_local.get('OL23919A')
+        assert result is not None
+        assert result.olid == 'OL23919A'
+
+
+@pytest.mark.integration
+class TestBulkFetch:
+    """Tests for get_many() — requires PR #440 to be merged."""
+
+    def test_get_many_mixed_types(self, ol_local):
+        if not hasattr(ol_local, 'get_many'):
+            pytest.skip("get_many() not available (requires PR #440)")
+        results = ol_local.get_many(['OL45804W', 'OL7353617M', 'OL23919A'])
+        assert len(results) == 3
+
+    def test_get_many_skips_missing(self, ol_local):
+        if not hasattr(ol_local, 'get_many'):
+            pytest.skip("get_many() not available (requires PR #440)")
+        results = ol_local.get_many(['OL45804W', 'OL9999999999W'])
+        assert len(results) == 1
+        assert results[0].olid == 'OL45804W'
+
+    def test_get_many_by_isbn(self, ol_local):
+        if not hasattr(ol_local, 'get_many_by_isbn'):
+            pytest.skip("get_many_by_isbn() not available (requires PR #440)")
+        results = ol_local.get_many_by_isbn(['9780439708180'])
+        assert len(results) >= 1
+        assert results[0].title

--- a/tests/integration/test_save.py
+++ b/tests/integration/test_save.py
@@ -1,0 +1,70 @@
+"""
+Integration tests for write/save operations.
+
+These tests require a running OL instance with write credentials:
+
+    OL_TEST_URL=http://localhost:8080 \
+    OL_USERNAME=openlibrary@example.com \
+    OL_PASSWORD=admin123 \
+    pytest tests/integration/test_save.py -m integration -v
+
+WARNING: These tests make real edits to the OL instance pointed at by
+OL_TEST_URL. Only run against a local Docker instance, never against
+openlibrary.org.
+"""
+
+import os
+
+import pytest
+
+
+def requires_write_auth(ol_local):
+    """Skip if OL_USERNAME/OL_PASSWORD were not provided."""
+    if not os.environ.get("OL_USERNAME"):
+        pytest.skip("OL_USERNAME not set — write tests require auth")
+
+
+@pytest.mark.integration
+class TestEditionSave:
+    def test_save_edition_title_change(self, ol_local):
+        requires_write_auth(ol_local)
+
+        e = ol_local.Edition.get('OL7353617M')
+        assert e is not None
+
+        original_title = e.title
+        e.title = original_title + " (integration test)"
+        e.save("integration test: title change")
+
+        # Verify the change persisted
+        e2 = ol_local.Edition.get('OL7353617M')
+        assert e2.title == e.title
+
+        # Restore original title
+        e2.title = original_title
+        e2.save("integration test: restore title")
+
+        e3 = ol_local.Edition.get('OL7353617M')
+        assert e3.title == original_title
+
+
+@pytest.mark.integration
+class TestWorkSave:
+    def test_save_work_description_change(self, ol_local):
+        requires_write_auth(ol_local)
+
+        w = ol_local.Work.get('OL45804W')
+        assert w is not None
+
+        # Store original description (may be None)
+        original_desc = getattr(w, 'description', None)
+        w.description = "Integration test description — safe to revert."
+        w.save("integration test: description change")
+
+        # Verify
+        w2 = ol_local.Work.get('OL45804W')
+        assert w2.description == w.description
+
+        # Restore
+        w2.description = original_desc
+        w2.save("integration test: restore description")


### PR DESCRIPTION
## Summary

Adds a pytest-based integration test framework so the client can be verified against a real running OL instance (local Docker or staging) — not just mocks.

## How it works

Integration tests are **skipped by default** and only activate when `OL_TEST_URL` is set:

```bash
# Read-only fetch tests (no auth needed)
OL_TEST_URL=http://localhost:8080 pytest tests/integration/ -m integration -v

# Write/save tests (need auth too)
OL_TEST_URL=http://localhost:8080 \
OL_USERNAME=openlibrary@example.com \
OL_PASSWORD=admin123 \
pytest tests/integration/ -m integration -v
```

## What's added

### `tests/conftest.py`
- `ol_local` session-scoped fixture — builds an `OpenLibrary(base_url=OL_TEST_URL)` instance, optionally logs in if `OL_USERNAME`/`OL_PASSWORD` are set
- Registers the `integration` pytest marker

### `tests/integration/test_fetch.py`
- Work, Edition, Author fetch by OLID
- Edition fetch by ISBN
- `ol.get()` dispatch for all three types
- `get_many()` and `get_many_by_isbn()` tests (auto-skip if method not available — requires PR #440)

### `tests/integration/test_save.py`
- Edition title change + restore (verifies round-trip)
- Work description change + restore

### `pyproject.toml`
- Registers `integration` marker to silence pytest warnings

## CI

Integration tests do **not** run in GitHub Actions (no `OL_TEST_URL`). They're a local/staging verification tool for contributors working with a local Docker instance. Existing 46 unit tests still pass.

## Related

Part of the openlibrary-client improvement series (PR 4 of 5):
- PR #438: Fix CI deprecations (merged)
- PR #439: Local dev ergonomics (open)
- PR #440: Bulk fetch `get_many()` (open)
- **This PR**: Integration test infrastructure
- Next: Tag entity