### PR TITLE
feat(client): add Tag entity (get, create, save, dispatch)

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -742,6 +742,106 @@ class OpenLibrary:
 
         return Redirect
 
+    @property
+    def Tag(ol_self):
+        class Tag:
+            """Represents an Open Library Tag document (/tags/OLnT).
+
+            Tags are first-class OL entities used for controlled-vocabulary
+            subject tagging. Each tag has a name, a tag_type (e.g. "subject"),
+            an optional description, and optional body HTML.
+
+            Usage:
+                >>> tag = ol.Tag.get('OL32T')
+                >>> print(tag.name, tag.tag_type)
+                cooking subject
+            """
+
+            OL = ol_self
+
+            def __init__(self, olid, name, tag_type='subject', **kwargs):
+                self.olid = olid
+                self.name = name
+                self.tag_type = tag_type
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+            def json(self):
+                """Returns a dict representation suitable for saving to OL."""
+                exclude = {
+                    'olid',
+                    'revision',
+                    'latest_revision',
+                    'created',
+                    'last_modified',
+                }
+                data = {
+                    k: v for k, v in self.__dict__.items() if v is not None and k not in exclude
+                }
+                data['key'] = f'/tags/{self.olid}'
+                data['type'] = {'key': '/type/tag'}
+                return data
+
+            def save(self, comment):
+                """Saves this Tag back to Open Library using the JSON API."""
+                body = self.json()
+                body['_comment'] = comment
+                url = self.OL.base_url + f'/tags/{self.olid}.json'
+                return self.OL.session.put(url, json.dumps(body))
+
+            @classmethod
+            def get(cls, olid):
+                """Retrieves an OL Tag by olid (e.g. 'OL32T').
+
+                Returns:
+                    Tag instance, or None if not found.
+
+                Usage:
+                    >>> ol.Tag.get('OL32T')
+                """
+                path = f'/tags/{olid}.json'
+                r = cls.OL.get_ol_response(path)
+                if r is None:
+                    return None
+                try:
+                    data = r.json()
+                except Exception:
+                    return None
+                if 'error' in data:
+                    return None
+                _olid = data.pop('key', f'/tags/{olid}').split('/')[-1]
+                name = data.pop('name', '')
+                tag_type = data.pop('tag_type', 'subject')
+                # Strip read-only fields that callers can't set
+                data.pop('type', None)
+                return cls(_olid, name=name, tag_type=tag_type, **data)
+
+            @classmethod
+            def create(cls, name, tag_type, description='', comment='add tag'):
+                """Creates a new Tag in Open Library.
+
+                Args:
+                    name (str) - tag name (e.g. 'cooking')
+                    tag_type (str) - one of 'subject', 'genre', etc.
+                    description (str) - human-readable description
+                    comment (str) - edit comment
+
+                Returns:
+                    Response from save_many.
+
+                Usage:
+                    >>> ol.Tag.create('cooking', 'subject', 'Books about cooking')
+                """
+                tag = cls(
+                    olid='',  # OL assigns the OLID on creation
+                    name=name,
+                    tag_type=tag_type,
+                    tag_description=description or None,
+                )
+                return cls.OL.save_many([tag], comment)
+
+        return Tag
+
     def get(self, olid):
         _olid = olid.lower()
         if _olid.endswith('m'):
@@ -750,6 +850,8 @@ class OpenLibrary:
             return self.Work.get(olid)
         elif _olid.endswith('a'):
             return self.Author.get(olid)
+        elif _olid.endswith('t'):
+            return self.Tag.get(olid)
 
     @classmethod
     def get_primary_identifier(cls, book):

--- a/olclient/schemata/tag.schema.json
+++ b/olclient/schemata/tag.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Open Library Tag Schema",
+  "type": "object",
+  "required": [
+    "key",
+    "name",
+    "tag_type",
+    "type"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "key": {
+      "type": "string",
+      "pattern": "^/tags/OL[0-9]+T$"
+    },
+    "name": { "type": "string" },
+    "tag_type": { "type": "string" },
+    "tag_description": { "type": "string" },
+    "body": { "type": "string" },
+    "slugs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "tag_plugins": {
+      "type": "array"
+    },
+    "type": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "enum": ["/type/tag"]
+        }
+      }
+    },
+    "revision":        { "type": "number" },
+    "latest_revision": { "type": "number" },
+    "created":         { "$ref": "shared_definitions.json#/internal_datetime" },
+    "last_modified":   { "$ref": "shared_definitions.json#/internal_datetime" }
+  }
+}

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -421,3 +421,77 @@ class TestTextType(unittest.TestCase):
         self.assertIsInstance(work.description, str)
         self.assertIn('type', work.json()['description'])
         self.assertEqual(work.json()['description']['value'], "A Text Description")
+
+
+class TestTag(unittest.TestCase):
+    @patch('olclient.openlibrary.OpenLibrary.login')
+    def setUp(self, mock_login):
+        self.ol = OpenLibrary()
+
+    def test_tag_init(self):
+        tag = self.ol.Tag('OL32T', name='cooking', tag_type='subject')
+        assert tag.olid == 'OL32T'
+        assert tag.name == 'cooking'
+        assert tag.tag_type == 'subject'
+
+    def test_tag_init_kwargs(self):
+        tag = self.ol.Tag(
+            'OL32T',
+            name='cooking',
+            tag_type='subject',
+            tag_description='Books about cooking',
+        )
+        assert tag.tag_description == 'Books about cooking'
+
+    def test_tag_json(self):
+        tag = self.ol.Tag('OL32T', name='cooking', tag_type='subject')
+        data = tag.json()
+        assert data['key'] == '/tags/OL32T'
+        assert data['type'] == {'key': '/type/tag'}
+        assert data['name'] == 'cooking'
+        assert data['tag_type'] == 'subject'
+        # Read-only fields must not appear
+        assert 'olid' not in data
+        assert 'revision' not in data
+
+    def test_tag_json_excludes_none_values(self):
+        tag = self.ol.Tag('OL32T', name='cooking', tag_type='subject')
+        data = tag.json()
+        assert 'tag_description' not in data
+
+    @patch('requests.Session.get')
+    def test_tag_get(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            'key': '/tags/OL32T',
+            'name': 'cooking',
+            'tag_type': 'subject',
+            'tag_description': 'Books about cooking',
+            'type': {'key': '/type/tag'},
+        }
+        tag = self.ol.Tag.get('OL32T')
+        assert tag.olid == 'OL32T'
+        assert tag.name == 'cooking'
+        assert tag.tag_type == 'subject'
+        assert tag.tag_description == 'Books about cooking'
+
+    @patch('requests.Session.get')
+    def test_tag_get_not_found(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            'error': 'notfound',
+            'key': '/tags/OL9999T',
+        }
+        tag = self.ol.Tag.get('OL9999T')
+        assert tag is None
+
+    @patch('requests.Session.get')
+    def test_get_dispatches_to_tag(self, mock_get):
+        mock_get.return_value.json.return_value = {
+            'key': '/tags/OL32T',
+            'name': 'cooking',
+            'tag_type': 'subject',
+            'type': {'key': '/type/tag'},
+        }
+        result = self.ol.get('OL32T')
+        assert result is not None
+        assert result.olid == 'OL32T'
+        assert result.name == 'cooking'


### PR DESCRIPTION
## Summary

Adds `ol.Tag` as a first-class entity in `openlibrary-client`, alongside `ol.Work`, `ol.Edition`, and `ol.Author`.

OL Tags are Infogami documents at `/tags/OLnT` introduced in GSoC 2023. They provide a controlled vocabulary for subject tagging.

## New API

```python
ol = OpenLibrary()

# Fetch by OLID
tag = ol.Tag.get('OL32T')
# → Tag(olid='OL32T', name='cooking', tag_type='subject', ...)

# Generic dispatch (works via the 'T' suffix)
tag = ol.get('OL32T')

# Save a change
tag.tag_description = "Updated description"
tag.save("update description")

# Create a new tag (requires auth + save_many)
ol.Tag.create('science_fiction', 'subject', 'Works of speculative fiction')

# Serialize to OL JSON
tag.json()
# → {'key': '/tags/OL32T', 'type': {'key': '/type/tag'}, 'name': 'cooking', ...}
```

## What's included

- `ol.Tag` property (dynamic class factory, same pattern as Work/Edition/Author)
- `Tag.get(olid)` — fetches `/tags/{olid}.json`, returns `None` if not found
- `Tag.create(name, tag_type, description, comment)` — via `save_many`
- `tag.save(comment)` — `PUT /tags/{olid}.json`
- `tag.json()` — excludes read-only fields (`olid`, `revision`, `latest_revision`, `created`, `last_modified`), adds `key` and `type`
- `ol.get('OL32TÈ')` dispatch via the `T` suffix
- `olclient/schemata/tag.schema.json` — based on `/type/tag` and real OL documents

## Testing

```
pytest tests/ -x -q
53 passed (7 new Tag tests)
```

New tests cover: `Tag.__init__`, `tag.json()`, `Tag.get()`, `Tag.get()` returns None for missing tags, `ol.get()` dispatch to Tag.

## Related

Part of the openlibrary-client improvement series (PR 5 of 5):
- PR #438: Fix CI deprecations (merged)
- PR #439: Local dev ergonomics (open)
- PR #440: Bulk fetch `get_many()` (open)
- PR #441: Integration test infrastructure (open)
- **This PR**: Tag entity