### PR TITLE
fix(client): set Content-Type: application/json on session at init

### DIFF
--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -63,6 +63,7 @@ class OpenLibrary:
 
     def __init__(self, credentials=None, base_url='https://openlibrary.org'):
         self.session = requests.Session()
+        self.session.headers.update({'Content-Type': 'application/json'})
         self.base_url = base_url
         credentials = credentials or Config().get_config().get('s3', None)
         if credentials:


### PR DESCRIPTION
## Summary

Sets `Content-Type: application/json` on the requests session at init time.

Without this, ModSecurity WAF rule 920340 blocks all `POST /api/save_many` requests with 403 — the rule requires `Content-Type` to be present when `Content-Length` is non-zero. The `requests` library does not auto-set `Content-Type` for string `data=` bodies, so the header was never being sent.

Setting it at the session level ensures it is inherited by all subsequent requests (login, save_many, etc.).

## Test

```python
from olclient.openlibrary import OpenLibrary
from olclient.config import Config, Credentials

cfg = Config().get_config()
s3 = cfg['s3']
ol = OpenLibrary(credentials=Credentials(access=s3[0], secret=s3[1]))

class Doc:
    def __init__(self, data): self._data = data
    def json(self): return self._data

r = ol.save_many([Doc({'key': '/works/OL45804W', 'type': {'key': '/type/work'}})], 'test')
print(r.status_code)  # 200, not 403
```