### PR TITLE
Clean up unused imports (F401)

### DIFF
--- a/olclient/__init__.py
+++ b/olclient/__init__.py
@@ -13,6 +13,6 @@ __version__ = '0.0.31'
 __author__ = 'Internet Archive'
 
 
-from olclient.bots import AbstractBotJob
-from olclient.openlibrary import OpenLibrary
-from olclient.common import Book, Author
+from olclient.bots import AbstractBotJob as AbstractBotJob
+from olclient.openlibrary import OpenLibrary as OpenLibrary
+from olclient.common import Book as Book, Author as Author

--- a/olclient/openlibrary.py
+++ b/olclient/openlibrary.py
@@ -2,7 +2,7 @@
 
 
 import json
-from typing import List, Dict, Optional, Any
+from typing import List
 
 import jsonschema
 import logging
@@ -20,7 +20,6 @@ from requests import Response
 from olclient import common
 from olclient.config import Config
 from olclient.entity_helpers.work import get_work_helper_class
-from olclient.utils import merge_unique_lists
 
 logger = logging.getLogger('openlibrary')
 

--- a/olclient/utils.py
+++ b/olclient/utils.py
@@ -3,7 +3,6 @@
 
 import datetime
 import re
-from typing import Union
 
 ALPHANUMERICS_RE = re.compile(r'([^\s\w])+')
 

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -8,8 +8,7 @@ import unittest
 from argparse import ArgumentTypeError
 from olclient.openlibrary import OpenLibrary
 from olclient.bots import AbstractBotJob
-from os import path
-from unittest.mock import MagicMock, Mock, call, patch, ANY
+from unittest.mock import Mock, patch
 
 
 @patch('olclient.openlibrary.OpenLibrary.login')

--- a/tests/test_openlibrary.py
+++ b/tests/test_openlibrary.py
@@ -8,9 +8,8 @@ import pytest
 import requests
 import unittest
 
-from unittest.mock import Mock, call, patch, ANY
+from unittest.mock import call, patch, ANY
 
-from olclient.config import Config
 from olclient.common import Author, Book
 from olclient.openlibrary import OpenLibrary
 


### PR DESCRIPTION
Remove unused imports across the codebase flagged by Ruff rule F401. Uses explicit re-exports in __init__.py to preserve the public API.