### PR TITLE
Bump minor version of `simplejson`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ internetarchive==5.7.1
 jsonpickle==3.0.2
 jsonschema==4.21.1
 requests[security]==2.31.0
-simplejson==3.19.2
+simplejson==3.20.2


### PR DESCRIPTION
Updates `simplejson` to the version used by `internetarchive/openlibrary`:

https://github.com/internetarchive/openlibrary/blob/78a8009a83ce85a02b7f2ce6898d3df205c5b45a/requirements.txt#L38

This disparity prevents us from adding an `openlibrary-client` dependency to `internetarchive/openlibrary`.