### PR TITLE
Update dependencies for parity with openlibrary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,10 @@ classifiers = [
 ]
 dependencies = [
     "backoff==2.2.1",
-    "internetarchive==5.7.1",
+    "internetarchive==5.9.0",
     "jsonpickle==3.0.2",
     "jsonschema==4.21.1",
-    "requests[security]==2.31.0",
+    "requests[security]==2.34.2",
     "simplejson==3.20.2",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backoff==2.2.1
-internetarchive==5.7.1
+internetarchive==5.9.0
 jsonpickle==3.0.2
 jsonschema==4.21.1
-requests[security]==2.31.0
+requests[security]==2.34.2
 simplejson==3.20.2


### PR DESCRIPTION
Updates `internetarchive` and `requests`.  Now that these dependency's versions are the same, openlibrary can add openlibrary-client as a dependency.